### PR TITLE
feat(rendering): add nine-slice sprite support

### DIFF
--- a/src/rendering/components/sprite-component.test.ts
+++ b/src/rendering/components/sprite-component.test.ts
@@ -71,6 +71,54 @@ describe('addSpriteComponent', () => {
     expect(world.getComponent(entity, spriteId)).toBe(component);
   });
 
+  it('attaches nine-slice options when given valid insets and texture dimensions', () => {
+    const world = new EcsWorld();
+    const entity = world.createEntity();
+    const renderable = createRenderable();
+
+    addSpriteComponent(world, entity, {
+      width: 100,
+      height: 100,
+      renderable,
+      slices: { left: 16, right: 16, top: 16, bottom: 16 },
+      textureDimensions: new Vector2(64, 64),
+    });
+
+    expect(world.getComponent(entity, spriteId)).toMatchObject({
+      slices: { left: 16, right: 16, top: 16, bottom: 16 },
+      textureDimensions: new Vector2(64, 64),
+    });
+  });
+
+  it('throws when slices are given without texture dimensions', () => {
+    const world = new EcsWorld();
+    const entity = world.createEntity();
+
+    expect(() =>
+      addSpriteComponent(world, entity, {
+        width: 100,
+        height: 100,
+        renderable: createRenderable(),
+        slices: { left: 16, right: 16, top: 16, bottom: 16 },
+      }),
+    ).toThrow(/textureDimensions/);
+  });
+
+  it('throws when the slice insets do not fit the texture', () => {
+    const world = new EcsWorld();
+    const entity = world.createEntity();
+
+    expect(() =>
+      addSpriteComponent(world, entity, {
+        width: 100,
+        height: 100,
+        renderable: createRenderable(),
+        slices: { left: 40, right: 40, top: 16, bottom: 16 },
+        textureDimensions: new Vector2(64, 64),
+      }),
+    ).toThrow(/width/);
+  });
+
   it('gives each entity its own pivot, uvOffset, and uvScale vector instances', () => {
     const world = new EcsWorld();
     const first = world.createEntity();

--- a/src/rendering/components/sprite-component.ts
+++ b/src/rendering/components/sprite-component.ts
@@ -1,6 +1,11 @@
 import { createComponentId } from '../../ecs/ecs-component.js';
 import { EcsWorld } from '../../ecs/ecs-world.js';
 import { Color, Renderable, Vector2 } from '../../index.js';
+import {
+  NineSliceInsets,
+  SliceMode,
+  validateNineSliceInsets,
+} from '../utilities/nine-slice.js';
 
 /**
  * Fields of {@link SpriteEcsComponent} with no sensible default; callers
@@ -81,8 +86,42 @@ export interface SpriteDefaultedOptions {
   layer: number;
 }
 
+/**
+ * Fields of {@link SpriteEcsComponent} that are only meaningful for
+ * nine-sliced sprites, and are left unset for ordinary (single-quad)
+ * sprites.
+ */
+export interface SpriteSliceOptions {
+  /**
+   * The border insets, in texture pixels, that split this sprite into the
+   * classic nine-slice grid (four corners, four edges and a center). When
+   * set, the sprite is rendered as up to nine sub-quads whose corners keep
+   * their native size while the edges and center stretch to fill the
+   * sprite's `width`/`height`, so a resizable panel or frame keeps crisp
+   * borders. Leave unset for an ordinary single-quad sprite. Requires
+   * `textureDimensions` to be set, and is validated when the component is
+   * attached via `addSpriteComponent`.
+   */
+  slices?: NineSliceInsets;
+
+  /**
+   * How the stretchable regions of a nine-sliced sprite are filled. Defaults
+   * to `'stretch'`, the only value in v1; only meaningful alongside
+   * `slices`.
+   */
+  sliceMode?: SliceMode;
+
+  /**
+   * The source texture (or sampled frame) dimensions in pixels, used to turn
+   * the `slices` insets (given in texture pixels) into texture coordinates.
+   * Set automatically by `createImageSprite`; required whenever `slices` is
+   * set.
+   */
+  textureDimensions?: Vector2;
+}
+
 export interface SpriteEcsComponent
-  extends SpriteRequiredOptions, SpriteDefaultedOptions {}
+  extends SpriteRequiredOptions, SpriteDefaultedOptions, SpriteSliceOptions {}
 
 export const spriteId = createComponentId<SpriteEcsComponent>('sprite');
 
@@ -118,6 +157,20 @@ export function addSpriteComponent(
     ...defaultSpriteOptions,
     ...options,
   };
+
+  if (component.slices) {
+    if (!component.textureDimensions) {
+      throw new Error(
+        'A nine-sliced sprite requires "textureDimensions" (the source texture size in pixels) so its insets can be resolved to texture coordinates.',
+      );
+    }
+
+    validateNineSliceInsets(
+      component.slices,
+      component.textureDimensions.x,
+      component.textureDimensions.y,
+    );
+  }
 
   return world.addComponent(entity, spriteId, component);
 }

--- a/src/rendering/renderable.ts
+++ b/src/rendering/renderable.ts
@@ -7,6 +7,7 @@ import type {
 import type { SpriteEcsComponent } from './components/index.js';
 import type { Geometry } from './geometry/index.js';
 import type { Material } from './materials/index.js';
+import type { NineSliceInstance } from './utilities/nine-slice.js';
 
 /**
  * The components needed to bind an entity's per-instance data, resolved once
@@ -38,6 +39,14 @@ export interface InstanceComponents {
    * The entity's flip flags, if it has any.
    */
   flip: FlipEcsComponent | null;
+
+  /**
+   * For one sub-quad of a nine-sliced sprite, the size, pivot and texture
+   * region that override the sprite's own so this instance draws just that
+   * slice. Absent for ordinary (single-quad) sprites, which draw from the
+   * sprite's own size, pivot and texture region.
+   */
+  sliceInstance?: NineSliceInstance | null;
 }
 
 /**

--- a/src/rendering/systems/render-system.test.ts
+++ b/src/rendering/systems/render-system.test.ts
@@ -6,7 +6,7 @@ import { PositionEcsComponent, positionId } from '../../common';
 import { Vector2 } from '../../math';
 import { CameraEcsComponent, cameraId } from '../components';
 import { SpriteEcsComponent, spriteId } from '../components';
-import { Renderable } from '../renderable';
+import { InstanceComponents, Renderable } from '../renderable';
 import { RenderContext } from '../render-context';
 import { RenderTarget } from '../render-target';
 import { Color } from '../color';
@@ -441,6 +441,70 @@ describe('createRenderEcsSystem', () => {
     world.update();
 
     expect(mockGl.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a nine-sliced sprite as nine instances in a single draw call', () => {
+    addCameraEntity();
+    const { renderable, bindInstanceData } = createRenderable(4);
+
+    addSpriteEntity(renderable, 0, {
+      width: 100,
+      height: 100,
+      pivot: new Vector2(0.5, 0.5),
+      uvOffset: Vector2.zero,
+      uvScale: Vector2.one,
+      slices: { left: 16, right: 16, top: 16, bottom: 16 },
+      textureDimensions: new Vector2(64, 64),
+    });
+
+    world.update();
+
+    expect(bindInstanceData).toHaveBeenCalledTimes(9);
+    expect(mockGl.drawArraysInstanced).toHaveBeenCalledTimes(1);
+    expect(mockGl.drawArraysInstanced).toHaveBeenCalledWith(undefined, 0, 6, 9);
+
+    // Each sub-quad carries its own slice override, distinct from the others.
+    const sliceSizes = bindInstanceData.mock.calls.map((call) =>
+      (call[0] as InstanceComponents).sliceInstance?.size.toString(),
+    );
+
+    expect(new Set(sliceSizes).size).toBeGreaterThan(1);
+  });
+
+  it('collapses a nine-sliced sprite with no horizontal insets to three instances', () => {
+    addCameraEntity();
+    const { renderable, bindInstanceData } = createRenderable(4);
+
+    addSpriteEntity(renderable, 0, {
+      width: 100,
+      height: 100,
+      pivot: new Vector2(0.5, 0.5),
+      uvOffset: Vector2.zero,
+      uvScale: Vector2.one,
+      slices: { left: 0, right: 0, top: 16, bottom: 16 },
+      textureDimensions: new Vector2(64, 64),
+    });
+
+    world.update();
+
+    expect(bindInstanceData).toHaveBeenCalledTimes(3);
+    expect(mockGl.drawArraysInstanced).toHaveBeenCalledWith(undefined, 0, 6, 3);
+  });
+
+  it('treats a sprite with slices but no texture dimensions as a single quad', () => {
+    addCameraEntity();
+    const { renderable, bindInstanceData } = createRenderable(4);
+
+    addSpriteEntity(renderable, 0, {
+      width: 100,
+      height: 100,
+      slices: { left: 16, right: 16, top: 16, bottom: 16 },
+    });
+
+    world.update();
+
+    expect(bindInstanceData).toHaveBeenCalledTimes(1);
+    expect(mockGl.drawArraysInstanced).toHaveBeenCalledWith(undefined, 0, 6, 1);
   });
 
   it('clears again on the next frame', () => {

--- a/src/rendering/systems/render-system.ts
+++ b/src/rendering/systems/render-system.ts
@@ -22,6 +22,7 @@ import { RenderTarget } from '../render-target.js';
 import { InstanceComponents, Renderable } from '../renderable.js';
 import { createProjectionMatrix } from '../shaders/index.js';
 import { RenderCommand } from '../render-command.js';
+import { computeNineSliceInstances } from '../utilities/nine-slice.js';
 
 /**
  * The result of a single camera's `run` pass. `afterRun` receives one of
@@ -211,6 +212,36 @@ export const createRenderEcsSystem = (
         sprite: spriteComponent,
         flip: world.getComponent<FlipEcsComponent>(spriteEntity, flipId),
       };
+
+      // A nine-sliced sprite renders as several sub-quads (up to nine), each
+      // pushed as its own command so it flows through the existing
+      // one-command-per-instance batching unchanged: the sub-quads share the
+      // sprite's renderable, layer and depth, so they stay batched and sorted
+      // together, and differ only in the per-slice size, pivot and texture
+      // region carried on `sliceInstance`.
+      if (spriteComponent.slices && spriteComponent.textureDimensions) {
+        const sliceInstances = computeNineSliceInstances({
+          width: spriteComponent.width,
+          height: spriteComponent.height,
+          textureWidth: spriteComponent.textureDimensions.x,
+          textureHeight: spriteComponent.textureDimensions.y,
+          insets: spriteComponent.slices,
+          pivot: spriteComponent.pivot,
+          uvOffset: spriteComponent.uvOffset,
+          uvScale: spriteComponent.uvScale,
+        });
+
+        for (const sliceInstance of sliceInstances) {
+          commands.push({
+            layer: spriteComponent.layer,
+            depth: entityPosition.world.y,
+            renderable,
+            components: { ...components, sliceInstance },
+          });
+        }
+
+        continue;
+      }
 
       commands.push({
         layer: spriteComponent.layer,

--- a/src/rendering/utilities/create-image-sprite.ts
+++ b/src/rendering/utilities/create-image-sprite.ts
@@ -1,8 +1,11 @@
 import {
   Color,
   createQuadGeometry,
+  NineSliceInsets,
   Renderable,
+  SliceMode,
   SpriteEcsComponent,
+  validateNineSliceInsets,
   Vector2,
 } from '../../index.js';
 import { Material } from '../materials/index.js';
@@ -54,6 +57,22 @@ export interface CreateImageSpriteOptions {
    * by lighting. Omit for a sprite with no emissive contribution.
    */
   emissiveMap?: EmissiveMapOptions;
+
+  /**
+   * The border insets, in texture pixels, that render this sprite as a
+   * nine-slice (four corners that keep their native size, four edges that
+   * stretch along one axis, and a center that stretches along both). Insets
+   * are measured against the sprite's frame size (`frameDimensions`, or the
+   * full image when omitted). Omit for an ordinary single-quad sprite.
+   */
+  slices?: NineSliceInsets;
+
+  /**
+   * How the stretchable regions of a nine-sliced sprite are filled. Defaults
+   * to `'stretch'` (the only value in v1); only meaningful alongside
+   * `slices`.
+   */
+  sliceMode?: SliceMode;
 }
 
 // `color` isn't included here: `Color.white` can't be read at module-init
@@ -118,15 +137,31 @@ export function createImageSprite(
     setupInstanceAttributes,
   );
 
+  const textureDimensions = new Vector2(
+    options.frameDimensions?.x ?? image.width,
+    options.frameDimensions?.y ?? image.height,
+  );
+
+  if (options.slices) {
+    validateNineSliceInsets(
+      options.slices,
+      textureDimensions.x,
+      textureDimensions.y,
+    );
+  }
+
   return {
     enabled: true,
-    width: options.frameDimensions?.x ?? image.width,
-    height: options.frameDimensions?.y ?? image.height,
+    width: textureDimensions.x,
+    height: textureDimensions.y,
     pivot: new Vector2(0.5, 0.5),
     tintColor: Color.white,
     renderable,
     uvOffset: new Vector2(0, 0),
     uvScale: new Vector2(1, 1),
     layer: 0,
+    slices: options.slices,
+    sliceMode: options.sliceMode,
+    textureDimensions,
   };
 }

--- a/src/rendering/utilities/index.ts
+++ b/src/rendering/utilities/index.ts
@@ -4,5 +4,6 @@ export * from './create-image-sprite.js';
 export * from './create-shader-cache.js';
 export * from './create-sprite.js';
 export * from './instance-data-segment.js';
+export * from './nine-slice.js';
 export * from './setup-instance-attribute.js';
 export * from './sprite-instance-data-segment.js';

--- a/src/rendering/utilities/nine-slice.test.ts
+++ b/src/rendering/utilities/nine-slice.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeNineSliceInstances,
+  NineSliceParams,
+  validateNineSliceInsets,
+} from './nine-slice.js';
+import { Vector2 } from '../../math/index.js';
+
+const baseParams = (
+  overrides: Partial<NineSliceParams> = {},
+): NineSliceParams => ({
+  width: 100,
+  height: 100,
+  textureWidth: 64,
+  textureHeight: 64,
+  insets: { left: 16, right: 16, top: 16, bottom: 16 },
+  pivot: new Vector2(0.5, 0.5),
+  uvOffset: new Vector2(0, 0),
+  uvScale: new Vector2(1, 1),
+  ...overrides,
+});
+
+describe('computeNineSliceInstances', () => {
+  it('emits nine sub-quads, top-to-bottom then left-to-right, for non-zero insets on both axes', () => {
+    const instances = computeNineSliceInstances(baseParams());
+
+    expect(instances).toHaveLength(9);
+  });
+
+  it('gives every corner its native (inset) size regardless of the sprite size', () => {
+    for (const size of [50, 100, 200, 1000]) {
+      const instances = computeNineSliceInstances(
+        baseParams({ width: size, height: size }),
+      );
+
+      const corners = [instances[0], instances[2], instances[6], instances[8]];
+
+      for (const corner of corners) {
+        expect(corner.size).toEqual(new Vector2(16, 16));
+      }
+    }
+  });
+
+  it('stretches edges along one axis and the center along both', () => {
+    const instances = computeNineSliceInstances(
+      baseParams({ width: 100, height: 100 }),
+    );
+
+    // Top edge: native height, stretched width (100 - 16 - 16 = 68).
+    expect(instances[1].size).toEqual(new Vector2(68, 16));
+    // Left edge: stretched height, native width.
+    expect(instances[3].size).toEqual(new Vector2(16, 68));
+    // Center: stretched on both axes.
+    expect(instances[4].size).toEqual(new Vector2(68, 68));
+  });
+
+  it('maps each slice to the correct texture region for a known texture and insets', () => {
+    const instances = computeNineSliceInstances(baseParams());
+
+    // Top-left corner samples the top-left 16px of the 64px texture.
+    expect(instances[0].uvOffset).toEqual(new Vector2(0, 0));
+    expect(instances[0].uvScale).toEqual(new Vector2(0.25, 0.25));
+
+    // Center samples the inner region between the insets.
+    expect(instances[4].uvOffset).toEqual(new Vector2(0.25, 0.25));
+    expect(instances[4].uvScale).toEqual(new Vector2(0.5, 0.5));
+
+    // Bottom-right corner samples the bottom-right 16px.
+    expect(instances[8].uvOffset).toEqual(new Vector2(0.75, 0.75));
+    expect(instances[8].uvScale).toEqual(new Vector2(0.25, 0.25));
+  });
+
+  it('distinguishes the left and right texture columns (asymmetric insets)', () => {
+    const instances = computeNineSliceInstances(
+      baseParams({ insets: { left: 8, right: 24, top: 16, bottom: 16 } }),
+    );
+
+    // Left column: native width 8, texture region [0, 8/64] = [0, 0.125].
+    expect(instances[0].size.x).toBe(8);
+    expect(instances[0].uvOffset.x).toBeCloseTo(0);
+    expect(instances[0].uvScale.x).toBeCloseTo(0.125);
+
+    // Right column: native width 24, texture region [(64 - 24)/64, 1].
+    expect(instances[2].size.x).toBe(24);
+    expect(instances[2].uvOffset.x).toBeCloseTo(0.625);
+    expect(instances[2].uvScale.x).toBeCloseTo(0.375);
+  });
+
+  it('encodes the exact pivot/size the sprite shader needs to position each slice', () => {
+    const instances = computeNineSliceInstances(baseParams());
+
+    // Derived from the shader's own pivot math
+    // `startEdge = (-0.5 - pivot) * size * 0.5` solved per segment.
+    expect(instances[0].pivot).toEqual(new Vector2(5.75, 5.75)); // top-left
+    expect(instances[4].pivot).toEqual(new Vector2(0.5, 0.5)); // center
+    expect(instances[8].pivot).toEqual(new Vector2(-4.75, -4.75)); // bottom-right
+  });
+
+  it('composes slice texture regions with the sprite’s own uvOffset/uvScale (atlas frame)', () => {
+    const instances = computeNineSliceInstances(
+      baseParams({
+        uvOffset: new Vector2(0.1, 0.2),
+        uvScale: new Vector2(0.5, 0.5),
+      }),
+    );
+
+    // Top-left corner: base offset, plus zero fraction, scaled into the frame.
+    expect(instances[0].uvOffset).toEqual(new Vector2(0.1, 0.2));
+    expect(instances[0].uvScale).toEqual(new Vector2(0.25 * 0.5, 0.25 * 0.5));
+
+    // Center: base offset + 0.25 fraction of the 0.5-wide frame.
+    expect(instances[4].uvOffset).toEqual(
+      new Vector2(0.1 + 0.25 * 0.5, 0.2 + 0.25 * 0.5),
+    );
+  });
+
+  it('collapses a zero-inset axis instead of emitting zero-area quads', () => {
+    // No horizontal insets: one column, three rows.
+    const instances = computeNineSliceInstances(
+      baseParams({ insets: { left: 0, right: 0, top: 16, bottom: 16 } }),
+    );
+
+    expect(instances).toHaveLength(3);
+
+    for (const instance of instances) {
+      expect(instance.size.x).toBe(100);
+      expect(instance.uvScale.x).toBe(1);
+    }
+  });
+
+  it('reduces to a single quad identical to the un-sliced sprite when all insets are zero', () => {
+    const params = baseParams({
+      insets: { left: 0, right: 0, top: 0, bottom: 0 },
+      pivot: new Vector2(0.3, 0.7),
+      uvOffset: new Vector2(0.1, 0.2),
+      uvScale: new Vector2(0.5, 0.6),
+    });
+
+    const instances = computeNineSliceInstances(params);
+
+    expect(instances).toHaveLength(1);
+    expect(instances[0].size).toEqual(new Vector2(100, 100));
+    // The pivot is reconstructed through the shader's own algebra, so it
+    // matches to floating-point precision rather than bit-for-bit.
+    expect(instances[0].pivot.x).toBeCloseTo(params.pivot.x);
+    expect(instances[0].pivot.y).toBeCloseTo(params.pivot.y);
+    expect(instances[0].uvOffset).toEqual(params.uvOffset);
+    expect(instances[0].uvScale).toEqual(params.uvScale);
+  });
+});
+
+describe('validateNineSliceInsets', () => {
+  it('accepts insets that leave room for a center on both axes', () => {
+    expect(() =>
+      validateNineSliceInsets(
+        { left: 16, right: 16, top: 16, bottom: 16 },
+        64,
+        64,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects negative insets', () => {
+    expect(() =>
+      validateNineSliceInsets(
+        { left: -1, right: 16, top: 16, bottom: 16 },
+        64,
+        64,
+      ),
+    ).toThrow(/non-negative/);
+  });
+
+  it('rejects horizontal insets that meet or exceed the texture width', () => {
+    expect(() =>
+      validateNineSliceInsets(
+        { left: 40, right: 30, top: 16, bottom: 16 },
+        64,
+        64,
+      ),
+    ).toThrow(/width/);
+  });
+
+  it('rejects vertical insets that meet or exceed the texture height', () => {
+    expect(() =>
+      validateNineSliceInsets(
+        { left: 16, right: 16, top: 40, bottom: 40 },
+        64,
+        64,
+      ),
+    ).toThrow(/height/);
+  });
+});

--- a/src/rendering/utilities/nine-slice.ts
+++ b/src/rendering/utilities/nine-slice.ts
@@ -1,0 +1,267 @@
+import { Vector2 } from '../../math/index.js';
+
+/**
+ * How the stretchable regions of a nine-sliced sprite are filled.
+ *
+ * Declared as a literal union (rather than a bare `string`) so additional
+ * modes can be added later without a breaking change. `'stretch'` is the
+ * only value in v1 and the default: the edges and center are stretched to
+ * fill the sprite. `'tile'` (repeating the source region instead of
+ * stretching it) is intentionally deferred.
+ */
+export type SliceMode = 'stretch';
+
+/**
+ * The border insets, in texture pixels, that split a sprite's texture into
+ * the classic nine-slice grid (four corners, four edges and a center).
+ *
+ * This is the industry-standard convention shared by Unity's 9-slice, CSS
+ * `border-image` and Godot's `NinePatchRect`: `left`/`right` measure in from
+ * the texture's left/right edges and `top`/`bottom` from its top/bottom
+ * edges. The corners keep their native size, the edges stretch along a single
+ * axis and the center stretches along both.
+ */
+export interface NineSliceInsets {
+  /** Distance, in texture pixels, of the left column of slices. */
+  left: number;
+
+  /** Distance, in texture pixels, of the right column of slices. */
+  right: number;
+
+  /** Distance, in texture pixels, of the top row of slices. */
+  top: number;
+
+  /** Distance, in texture pixels, of the bottom row of slices. */
+  bottom: number;
+}
+
+/**
+ * A single sub-quad of a nine-sliced sprite, expressed in the exact terms the
+ * standard sprite pipeline already consumes per instance. Emitting one of
+ * these per non-empty slice lets a sliced sprite reuse the shared sprite
+ * vertex shader unchanged: each sub-quad is just another instance with its
+ * own size, pivot and texture region, sharing the parent sprite's position,
+ * rotation, scale and tint.
+ */
+export interface NineSliceInstance {
+  /** The sub-quad's world size (width, height). */
+  size: Vector2;
+
+  /**
+   * The sub-quad's pivot, encoded so that the shared sprite shader places the
+   * sub-quad at its correct offset within the parent sprite while still
+   * pivoting, rotating and scaling around the parent sprite's origin. May lie
+   * outside `[0, 1]`; it is a positional encoding, not a user-facing pivot.
+   */
+  pivot: Vector2;
+
+  /** The top-left of the sub-quad's texture region, in normalized UV space. */
+  uvOffset: Vector2;
+
+  /** The size of the sub-quad's texture region, in normalized UV space. */
+  uvScale: Vector2;
+}
+
+/**
+ * The inputs needed to expand a nine-sliced sprite into its sub-quads.
+ */
+export interface NineSliceParams {
+  /** The sprite's current world width. */
+  width: number;
+
+  /** The sprite's current world height. */
+  height: number;
+
+  /** The source texture (or sampled frame) width, in pixels. */
+  textureWidth: number;
+
+  /** The source texture (or sampled frame) height, in pixels. */
+  textureHeight: number;
+
+  /** The border insets, in texture pixels. */
+  insets: NineSliceInsets;
+
+  /** The parent sprite's pivot, normalized to its size. */
+  pivot: Vector2;
+
+  /** The parent sprite's texture region offset, in normalized UV space. */
+  uvOffset: Vector2;
+
+  /** The parent sprite's texture region size, in normalized UV space. */
+  uvScale: Vector2;
+}
+
+/**
+ * A single-axis slice segment, in the terms the sprite shader consumes.
+ */
+interface AxisSegment {
+  /** The segment's world size along this axis. */
+  size: number;
+
+  /** The pivot encoding that positions the segment along this axis. */
+  pivot: number;
+
+  /** The segment's texture region offset along this axis (normalized). */
+  uvOffset: number;
+
+  /** The segment's texture region size along this axis (normalized). */
+  uvScale: number;
+}
+
+/**
+ * Validates a set of nine-slice insets against the texture they refer to.
+ * @param insets - The insets to validate, in texture pixels.
+ * @param textureWidth - The source texture width, in pixels.
+ * @param textureHeight - The source texture height, in pixels.
+ * @throws An error if any inset is negative, or if the horizontal or vertical
+ * insets meet or overlap (i.e. leave no room for a center slice).
+ */
+export function validateNineSliceInsets(
+  insets: NineSliceInsets,
+  textureWidth: number,
+  textureHeight: number,
+): void {
+  const { left, right, top, bottom } = insets;
+
+  if (left < 0 || right < 0 || top < 0 || bottom < 0) {
+    throw new Error(
+      `Nine-slice insets must be non-negative, but got left=${left}, right=${right}, top=${top}, bottom=${bottom}.`,
+    );
+  }
+
+  if (left + right >= textureWidth) {
+    throw new Error(
+      `Nine-slice horizontal insets (left=${left} + right=${right}) must be less than the texture width (${textureWidth}).`,
+    );
+  }
+
+  if (top + bottom >= textureHeight) {
+    throw new Error(
+      `Nine-slice vertical insets (top=${top} + bottom=${bottom}) must be less than the texture height (${textureHeight}).`,
+    );
+  }
+}
+
+/**
+ * Splits one axis into up to three segments (start border, stretchable
+ * middle, end border), skipping any segment with no size so that a zero inset
+ * collapses cleanly instead of emitting a degenerate zero-area quad.
+ */
+function sliceAxis(
+  fullSize: number,
+  pivot: number,
+  textureSize: number,
+  insetStart: number,
+  insetEnd: number,
+  baseUvOffset: number,
+  baseUvScale: number,
+): AxisSegment[] {
+  // Cumulative geometry edges, in world units, from the axis' start edge:
+  // the two borders keep their native (inset) size and the middle absorbs
+  // whatever world size is left over.
+  const geometryEdges = [0, insetStart, fullSize - insetEnd, fullSize];
+
+  // Cumulative texture edges, as normalized fractions of the sampled region:
+  // unlike the geometry, the borders keep their texture fraction and the
+  // middle is the fraction left over, so the border texels never stretch.
+  const textureEdges = [
+    0,
+    insetStart / textureSize,
+    (textureSize - insetEnd) / textureSize,
+    1,
+  ];
+
+  // The world-space position of this axis' start edge relative to the parent
+  // sprite's pivot origin, matching the sprite shader's own pivot math
+  // (`(a_position - (pivot - 0.5)) * size * 0.5`).
+  const startEdge = (-0.5 - pivot) * fullSize * 0.5;
+
+  const segments: AxisSegment[] = [];
+
+  for (let i = 0; i < 3; i++) {
+    const size = geometryEdges[i + 1] - geometryEdges[i];
+
+    if (size <= 0) {
+      continue;
+    }
+
+    const segmentStart = startEdge + geometryEdges[i];
+
+    segments.push({
+      size,
+      // Solve the shader's pivot math for the pivot that lands this segment's
+      // start edge at `segmentStart` given its `size`.
+      pivot: -0.5 - (2 * segmentStart) / size,
+      uvOffset: baseUvOffset + textureEdges[i] * baseUvScale,
+      uvScale: (textureEdges[i + 1] - textureEdges[i]) * baseUvScale,
+    });
+  }
+
+  return segments;
+}
+
+/**
+ * Expands a nine-sliced sprite into the sub-quads that render it, computed
+ * from the sprite's current size, its texture dimensions and the insets.
+ *
+ * Corners keep their native (inset) world size, edges stretch along one axis
+ * and the center stretches along both, all expressed as sprite-shader
+ * instances so no shader change is needed. With non-zero insets on both axes
+ * this returns nine instances, ordered top-to-bottom then left-to-right; a
+ * zero inset collapses the affected row/column, so fewer instances are
+ * returned (for example, insets of zero on both axes return a single instance
+ * identical to the un-sliced sprite).
+ * @param params - The sprite size, texture dimensions, insets, pivot and
+ * texture region.
+ * @returns The sub-quad instances, in row-major (top-to-bottom,
+ * left-to-right) order.
+ */
+export function computeNineSliceInstances(
+  params: NineSliceParams,
+): NineSliceInstance[] {
+  const {
+    width,
+    height,
+    textureWidth,
+    textureHeight,
+    insets,
+    pivot,
+    uvOffset,
+    uvScale,
+  } = params;
+
+  const columns = sliceAxis(
+    width,
+    pivot.x,
+    textureWidth,
+    insets.left,
+    insets.right,
+    uvOffset.x,
+    uvScale.x,
+  );
+
+  const rows = sliceAxis(
+    height,
+    pivot.y,
+    textureHeight,
+    insets.top,
+    insets.bottom,
+    uvOffset.y,
+    uvScale.y,
+  );
+
+  const instances: NineSliceInstance[] = [];
+
+  for (const row of rows) {
+    for (const column of columns) {
+      instances.push({
+        size: new Vector2(column.size, row.size),
+        pivot: new Vector2(column.pivot, row.pivot),
+        uvOffset: new Vector2(column.uvOffset, row.uvOffset),
+        uvScale: new Vector2(column.uvScale, row.uvScale),
+      });
+    }
+  }
+
+  return instances;
+}

--- a/src/rendering/utilities/sprite-instance-data-segment.test.ts
+++ b/src/rendering/utilities/sprite-instance-data-segment.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SPRITE_INSTANCE_DATA_FLOATS_PER_INSTANCE,
+  spriteInstanceDataSegment,
+} from './sprite-instance-data-segment.js';
+import { PositionEcsComponent } from '../../common/index.js';
+import { Vector2 } from '../../math/index.js';
+import { Color } from '../color.js';
+import { SpriteEcsComponent } from '../components/index.js';
+import { Geometry } from '../geometry/geometry.js';
+import { Material } from '../materials/material.js';
+import { InstanceComponents, Renderable } from '../renderable.js';
+
+const createSprite = (): SpriteEcsComponent => ({
+  width: 40,
+  height: 20,
+  renderable: new Renderable(
+    { bind: vi.fn() } as unknown as Geometry,
+    { bind: vi.fn(), program: {} } as unknown as Material,
+    SPRITE_INSTANCE_DATA_FLOATS_PER_INSTANCE,
+    0,
+    vi.fn(),
+    vi.fn(),
+  ),
+  pivot: new Vector2(0.5, 0.5),
+  tintColor: new Color(0.1, 0.2, 0.3, 0.4),
+  uvOffset: new Vector2(0.11, 0.12),
+  uvScale: new Vector2(0.5, 0.6),
+  enabled: true,
+  layer: 0,
+});
+
+const createComponents = (
+  sprite: SpriteEcsComponent,
+  sliceInstance?: InstanceComponents['sliceInstance'],
+): InstanceComponents => {
+  const position: PositionEcsComponent = {
+    local: new Vector2(7, 9),
+    world: new Vector2(7, 9),
+  };
+
+  return {
+    position,
+    rotation: null,
+    scale: null,
+    sprite,
+    flip: null,
+    sliceInstance,
+  };
+};
+
+describe('spriteInstanceDataSegment.bindInstanceData', () => {
+  it('writes the sprite’s own size, pivot and texture region when it is not sliced', () => {
+    const sprite = createSprite();
+    const buffer = new Float32Array(SPRITE_INSTANCE_DATA_FLOATS_PER_INSTANCE);
+
+    spriteInstanceDataSegment.bindInstanceData(
+      createComponents(sprite),
+      buffer,
+      0,
+    );
+
+    // Compared through a Float32Array so both sides carry the same 32-bit
+    // rounding the instance buffer applies.
+    expect(Array.from(buffer)).toEqual(
+      Array.from(
+        new Float32Array([
+          7, // position x
+          -9, // position y (screen-space flip)
+          0, // rotation
+          1, // scale x
+          1, // scale y
+          40, // width
+          20, // height
+          0.5, // pivot x
+          0.5, // pivot y
+          0.11, // uv offset x
+          0.12, // uv offset y
+          0.5, // uv scale x
+          0.6, // uv scale y
+          0.1, // tint r
+          0.2, // tint g
+          0.3, // tint b
+          0.4, // tint a
+        ]),
+      ),
+    );
+  });
+
+  it('overrides size, pivot and texture region from the slice, keeping the sprite’s position and tint', () => {
+    const sprite = createSprite();
+    const buffer = new Float32Array(SPRITE_INSTANCE_DATA_FLOATS_PER_INSTANCE);
+
+    spriteInstanceDataSegment.bindInstanceData(
+      createComponents(sprite, {
+        size: new Vector2(16, 12),
+        pivot: new Vector2(5.75, -4.75),
+        uvOffset: new Vector2(0, 0.75),
+        uvScale: new Vector2(0.25, 0.25),
+      }),
+      buffer,
+      0,
+    );
+
+    // Size, pivot and texture region come from the slice...
+    expect(buffer[5]).toBe(16); // width
+    expect(buffer[6]).toBe(12); // height
+    expect(buffer[7]).toBe(5.75); // pivot x
+    expect(buffer[8]).toBe(-4.75); // pivot y
+    expect(buffer[9]).toBe(0); // uv offset x
+    expect(buffer[10]).toBe(0.75); // uv offset y
+    expect(buffer[11]).toBe(0.25); // uv scale x
+    expect(buffer[12]).toBe(0.25); // uv scale y
+
+    // ...while position and tint stay the parent sprite's.
+    expect(buffer[0]).toBe(7); // position x
+    expect(buffer[1]).toBe(-9); // position y
+    expect(buffer[13]).toBeCloseTo(0.1); // tint r
+    expect(buffer[16]).toBeCloseTo(0.4); // tint a
+  });
+});

--- a/src/rendering/utilities/sprite-instance-data-segment.ts
+++ b/src/rendering/utilities/sprite-instance-data-segment.ts
@@ -31,7 +31,17 @@ function bindSpriteInstanceData(
   instanceDataBufferArray: Float32Array,
   offset: number,
 ): void {
-  const { position, rotation, scale, sprite, flip } = components;
+  const { position, rotation, scale, sprite, flip, sliceInstance } = components;
+
+  // For a nine-sliced sprite, each sub-quad overrides the sprite's own size,
+  // pivot and texture region with its slice's; everything else (position,
+  // rotation, scale, tint) is shared with the parent sprite. Ordinary
+  // sprites have no `sliceInstance` and draw from the sprite directly.
+  const width = sliceInstance ? sliceInstance.size.x : sprite.width;
+  const height = sliceInstance ? sliceInstance.size.y : sprite.height;
+  const pivot = sliceInstance ? sliceInstance.pivot : sprite.pivot;
+  const uvOffset = sliceInstance ? sliceInstance.uvOffset : sprite.uvOffset;
+  const uvScale = sliceInstance ? sliceInstance.uvScale : sprite.uvScale;
 
   // Position
   instanceDataBufferArray[offset + POSITION_X_OFFSET] = position.world.x;
@@ -47,18 +57,18 @@ function bindSpriteInstanceData(
     (scale?.world.y ?? 1) * (flip?.flipY ? -1 : 1);
 
   // Sprite dimensions
-  instanceDataBufferArray[offset + WIDTH_OFFSET] = sprite.width;
-  instanceDataBufferArray[offset + HEIGHT_OFFSET] = sprite.height;
+  instanceDataBufferArray[offset + WIDTH_OFFSET] = width;
+  instanceDataBufferArray[offset + HEIGHT_OFFSET] = height;
 
   // Sprite pivot
-  instanceDataBufferArray[offset + PIVOT_X_OFFSET] = sprite.pivot.x;
-  instanceDataBufferArray[offset + PIVOT_Y_OFFSET] = sprite.pivot.y;
+  instanceDataBufferArray[offset + PIVOT_X_OFFSET] = pivot.x;
+  instanceDataBufferArray[offset + PIVOT_Y_OFFSET] = pivot.y;
 
   // Texture coordinates (animation frame or defaults)
-  instanceDataBufferArray[offset + TEX_OFFSET_X_OFFSET] = sprite.uvOffset.x;
-  instanceDataBufferArray[offset + TEX_OFFSET_Y_OFFSET] = sprite.uvOffset.y;
-  instanceDataBufferArray[offset + TEX_SIZE_X_OFFSET] = sprite.uvScale.x;
-  instanceDataBufferArray[offset + TEX_SIZE_Y_OFFSET] = sprite.uvScale.y;
+  instanceDataBufferArray[offset + TEX_OFFSET_X_OFFSET] = uvOffset.x;
+  instanceDataBufferArray[offset + TEX_OFFSET_Y_OFFSET] = uvOffset.y;
+  instanceDataBufferArray[offset + TEX_SIZE_X_OFFSET] = uvScale.x;
+  instanceDataBufferArray[offset + TEX_SIZE_Y_OFFSET] = uvScale.y;
 
   // Tint color
   instanceDataBufferArray[offset + TINT_COLOR_R_OFFSET] = sprite.tintColor.r;


### PR DESCRIPTION
Implements #471 as classic 9-slice (border insets, the Unity/CSS/Godot convention), stretch-mode v1.

## The seam, and one deliberate deviation from the issue's pointer

The issue points at `SpriteOptions` in `src/rendering/sprite.ts` — but on `dev`, that `Sprite` class is **particle-only** (its sole consumer is the particle emitter) and never reaches the renderer. The real render path is `SpriteEcsComponent` → one `RenderCommand` per sprite → instance-buffer fill → one instanced draw. So slicing lands there: **a sliced sprite emits one render command per non-empty slice** (up to 9), and every sub-quad flows through the existing sort/batch/buffer/draw path — zero changes to `includeBatch`, the draw call, `floatsPerInstance`, or any GLSL. Each sub-quad's placement is encoded by solving the shader's own pivot algebra, so rotation/scale/tint stay shared and correct for free.

## API

`slices?: { left, right, top, bottom }` (texture pixels) + `sliceMode?: 'stretch'` (literal union — `'tile'` becomes a non-breaking addition later) on the sprite component and `createImageSprite` (which auto-fills the new `textureDimensions` from the frame). Construction-time validation: non-negative insets, left+right < width, top+bottom < height. No `slices` → exactly the previous single-quad path (never calls the slice code); zero insets on an axis collapse cleanly instead of emitting degenerate quads.

## Design calls explicitly yours to overrule

1. Fields on the ECS component (+ `createImageSprite`), not the particle-only `Sprite` class — the biggest deviation from the issue's pointer, forced by the render path.
2. The new `textureDimensions` field (insets need a pixel reference); could instead fold into the `slices` object.
3. Corner convention: 1 texture pixel = 1 world unit (corners keep native size at any sprite scale); alternative is scaling corners by `width/textureWidth`.
4. Insets measure against the sampled frame, not the full atlas image.
5. `sliceMode` stored but not yet consumed ('stretch' is the only behavior).

Known v1 limits, documented in code: per-frame allocation of the 9 sub-instances (matches the existing per-entity-per-frame style; poolable later), and negative-scale flips mirror geometry but not per-cell UVs.

## Verification

All CI jobs run locally and green: ESLint (only pre-existing todo-tag warnings), tsc (tsconfig.ci), cspell, check-exports (node16 + bundler 🟢), build, **Vitest 936 passed / 130 files** (43 tests in the touched files), commitlint. The slice math is a pure function with direct tests. Mutation-checked (implementer, then independently re-run before opening): swapping geometry-edge insets, swapping UV-edge insets, flipping the pivot sign, and collapsing a sliced sprite to one emitted quad each fail exactly the tests that pin them — the last one re-verified by hand before this PR.

---
🤖 This PR was written with AI assistance (Claude), directed and verified by a human-supervised workflow.