### PR TITLE
docs(demos): design demos for a fixed 1920x1080 canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,6 +422,20 @@ import it, e.g. `grep -rl "/physics" documentation-site/src/pages/demos`):
 See also step 9 of `CLAUDE.md`'s verification checklist, which makes this
 mandatory before marking a task complete.
 
+**Demos assume a fixed 1920x1080 canvas.** Entity positions, spawn bounds,
+and layout math in demo code (e.g. `_create-boundaries.ts`,
+`_create-asteroids.ts`) use absolute pixel values authored against a
+1920x1080 world, not ratios derived from `renderContext.canvas.width` /
+`renderContext.canvas.height` or the live container size. Demos are not
+expected to look correct at any other canvas size. The canvas itself is
+still sized dynamically from its container (`createCanvas` /
+`RenderContext` are unchanged); only the entities placed inside it assume
+1920x1080. The exceptions are: mouse/pointer-to-world coordinate conversion
+(via `screenToWorldSpace`), which must keep using the live
+`renderContext.canvas` dimensions to map real cursor positions correctly,
+and GPU render target sizing (e.g. bloom/blur off-screen buffers), which
+must match the actual canvas resolution to composite correctly.
+
 ## Common Patterns
 
 ### Readonly Fields

--- a/documentation-site/src/pages/demos/brick-breaker/_create-background.ts
+++ b/documentation-site/src/pages/demos/brick-breaker/_create-background.ts
@@ -48,9 +48,10 @@ export function createBackground(
 
   const backgroundEntity = world.createEntity();
 
+  // The demo is designed for a fixed 1920x1080 canvas.
   addSpriteComponent(world, backgroundEntity, {
-    width: renderContext.canvas.width,
-    height: renderContext.canvas.height,
+    width: 1920,
+    height: 1080,
     renderable,
     layer: renderLayer,
   });

--- a/documentation-site/src/pages/demos/brick-breaker/_create-boundaries.ts
+++ b/documentation-site/src/pages/demos/brick-breaker/_create-boundaries.ts
@@ -48,7 +48,9 @@ export async function createBoundaries(
   );
   const wallSprite = createImageSprite(wallImage, renderContext, renderLayer);
 
-  const { width, height } = renderContext.canvas;
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const halfWidth = width / 2;
   const halfHeight = height / 2;
 

--- a/documentation-site/src/pages/demos/easing-functions/_create-easing-rows.ts
+++ b/documentation-site/src/pages/demos/easing-functions/_create-easing-rows.ts
@@ -118,7 +118,9 @@ export async function createEasingRows(
     renderLayer,
   );
 
-  const { width, height } = renderContext.canvas;
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const trackHalfWidth = width / 2 - horizontalMarginPixels;
   const minX = -trackHalfWidth * (1 - overshootMarginFraction);
   const maxX = trackHalfWidth * (1 - overshootMarginFraction);

--- a/documentation-site/src/pages/demos/linear-spring-damper/_create-suspensions.ts
+++ b/documentation-site/src/pages/demos/linear-spring-damper/_create-suspensions.ts
@@ -256,7 +256,10 @@ export async function createSuspensions(
   renderLayer: number,
 ): Promise<void> {
   const sprites = await loadSuspensionSprites(renderContext, renderLayer);
-  const { width, height } = renderContext.canvas;
+
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const columnWidth = width / 2;
   const mountY = height * 0.25;
   const stiffness = 30_000;

--- a/documentation-site/src/pages/demos/newtons-cradle/_create-game.ts
+++ b/documentation-site/src/pages/demos/newtons-cradle/_create-game.ts
@@ -27,7 +27,9 @@ export const createNewtonsCradleGame = async (): Promise<Game> => {
   });
 
   const physicsWorld = new PhysicsWorld({ gravity });
-  const { height } = renderContext.canvas;
+
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const height = 1080;
 
   await createCradle(
     world,

--- a/documentation-site/src/pages/demos/nine-slice/_create-panels.ts
+++ b/documentation-site/src/pages/demos/nine-slice/_create-panels.ts
@@ -87,16 +87,9 @@ export async function createPanels(
     },
   );
 
-  const { height } = renderContext.canvas;
-  const spacing = Math.min(height / 2, 160);
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const spacing = 160;
 
-  // Clamp the breathing range to whatever space is actually available, so
-  // panels never overlap each other or overflow the canvas on a narrow
-  // container (e.g. the docs site's demo box squeezed by its code panel).
-  const availableSize = Math.min(spacing, height);
-  const clampedMaxSize = Math.min(maxSize, availableSize);
-  const clampedMinSize = Math.min(minSize, clampedMaxSize);
-
-  placePanel(world, naiveSprite, 0, spacing, clampedMinSize, clampedMaxSize);
-  placePanel(world, stretchSprite, 0, -spacing, clampedMinSize, clampedMaxSize);
+  placePanel(world, naiveSprite, 0, spacing, minSize, maxSize);
+  placePanel(world, stretchSprite, 0, -spacing, minSize, maxSize);
 }

--- a/documentation-site/src/pages/demos/particles/_create-game.ts
+++ b/documentation-site/src/pages/demos/particles/_create-game.ts
@@ -26,8 +26,11 @@ const renderLayers = {
   foreground: 1 << 0,
 };
 
+// The demo is designed for a fixed 1920x1080 canvas.
+const canvasHeight = 1080;
+
 // Fraction of the canvas height up from the bottom edge that the ember
-// fountain sits at, so it stays in view regardless of canvas size.
+// fountain sits at.
 const fountainHeightFraction = 0.12;
 
 export const createParticlesGame = async (): Promise<Game> => {
@@ -48,8 +51,7 @@ export const createParticlesGame = async (): Promise<Game> => {
 
   const fountainPosition = new Vector2(
     0,
-    -renderContext.canvas.height / 2 +
-      renderContext.canvas.height * fountainHeightFraction,
+    -canvasHeight / 2 + canvasHeight * fountainHeightFraction,
   );
 
   await createEmberFountain(

--- a/documentation-site/src/pages/demos/physics/_create-boundaries.ts
+++ b/documentation-site/src/pages/demos/physics/_create-boundaries.ts
@@ -37,7 +37,9 @@ export async function createBoundaries(
   );
   const wallSprite = createImageSprite(wallImage, renderContext, renderLayer);
 
-  const { width, height } = renderContext.canvas;
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const halfWidth = width / 2;
   const halfHeight = height / 2;
 

--- a/documentation-site/src/pages/demos/physics/_spawn-shapes.ts
+++ b/documentation-site/src/pages/demos/physics/_spawn-shapes.ts
@@ -117,7 +117,9 @@ export async function spawnShapes(
 
   const random = new Random();
 
-  const { width, height } = renderContext.canvas;
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const halfWidth = width / 2;
   const halfHeight = height / 2;
 

--- a/documentation-site/src/pages/demos/prismatic-joint/_create-sliders.ts
+++ b/documentation-site/src/pages/demos/prismatic-joint/_create-sliders.ts
@@ -278,7 +278,10 @@ export async function createSliders(
   renderLayer: number,
 ): Promise<void> {
   const sprites = await loadSliderSprites(renderContext, renderLayer);
-  const { width, height } = renderContext.canvas;
+
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const columnWidth = width / 3;
   const columnLeft = -width / 2 + columnWidth / 2;
 

--- a/documentation-site/src/pages/demos/revolute-joint/_create-hinges.ts
+++ b/documentation-site/src/pages/demos/revolute-joint/_create-hinges.ts
@@ -327,7 +327,10 @@ export async function createHinges(
   renderLayer: number,
 ): Promise<void> {
   const sprites = await loadHingeSprites(renderContext, renderLayer);
-  const { width, height } = renderContext.canvas;
+
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const columnWidth = width / 3;
   const columnLeft = -width / 2 + columnWidth / 2;
 

--- a/documentation-site/src/pages/demos/space-shooter/_asteroid.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_asteroid.system.ts
@@ -6,12 +6,13 @@ import {
   rotationId,
   Time,
 } from '@forge-game-engine/forge/common';
-import { RenderContext } from '@forge-game-engine/forge/rendering';
 import { AsteroidEcsComponent, asteroidId } from './_asteroid.component';
+
+// The demo is designed for a fixed 1920x1080 canvas.
+const despawnY = -(1080 / 2 + 100);
 
 export const createAsteroidEcsSystem = (
   time: Time,
-  renderContext: RenderContext,
 ): EcsSystem<
   [AsteroidEcsComponent, PositionEcsComponent, RotationEcsComponent]
 > => ({
@@ -25,8 +26,6 @@ export const createAsteroidEcsSystem = (
 
     rotationComponent.world +=
       asteroidComponent.rotationSpeed * time.deltaTimeInSeconds;
-
-    const despawnY = -(renderContext.canvas.height / 2 + 100);
 
     if (positionComponent.world.y < despawnY) {
       world.removeEntity(result.entity);

--- a/documentation-site/src/pages/demos/space-shooter/_create-asteroids.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_create-asteroids.ts
@@ -34,13 +34,17 @@ export async function createAsteroidSpawner(
 
   const spawnerEntity = world.createEntity();
 
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const canvasWidth = 1920;
+  const canvasHeight = 1080;
+
   const spawnerComponent: AsteroidSpawnerEcsComponent = {
     asteroidSprites,
     timeBetweenSpawns: 0.2,
     nextSpawnTime: 0,
-    minX: -renderContext.canvas.width / 2,
-    maxX: renderContext.canvas.width / 2,
-    spawnY: renderContext.canvas.height / 2 + 100,
+    minX: -canvasWidth / 2,
+    maxX: canvasWidth / 2,
+    spawnY: canvasHeight / 2 + 100,
     minSpeed: 70,
     maxSpeed: 130,
     rotationSpeed: Math.PI / 6,

--- a/documentation-site/src/pages/demos/space-shooter/_create-background.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_create-background.ts
@@ -32,9 +32,13 @@ export async function createBackground(
     renderContext.gl,
   );
 
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const canvasWidth = 1920;
+  const canvasHeight = 1080;
+
   backgroundMaterial.setUniform(
     'u_resolution',
-    new Float32Array([renderContext.canvas.width, renderContext.canvas.height]),
+    new Float32Array([canvasWidth, canvasHeight]),
   );
 
   backgroundMaterial.setUniform(
@@ -67,8 +71,8 @@ export async function createBackground(
   const backgroundEntity = world.createEntity();
 
   addSpriteComponent(world, backgroundEntity, {
-    width: renderContext.canvas.width,
-    height: renderContext.canvas.height,
+    width: canvasWidth,
+    height: canvasHeight,
     renderable,
   });
 

--- a/documentation-site/src/pages/demos/space-shooter/_create-game.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_create-game.ts
@@ -52,9 +52,10 @@ const renderLayers = {
   foreground: 1 << 1,
 };
 
-// A fraction of the canvas's smaller dimension, so the shake reads as the
-// same proportional jolt regardless of the canvas's actual resolution.
+// The demo is designed for a fixed 1920x1080 canvas: a fraction of that
+// canvas's smaller (height) dimension.
 const explosionShakeIntensityFraction = 0.007;
+const explosionShakeIntensityPixels = explosionShakeIntensityFraction * 1080;
 const explosionShakeDurationSeconds = 0.15;
 
 export const bloomDefaults: BloomEcsComponent = {
@@ -120,7 +121,11 @@ export const createSpaceShooterGame = async (
   // foreground, so a bloom glow makes them read as glowing/energetic
   // instead of flat sprites. The component is handed back to the caller
   // (see the sliders on this demo's page) so it can be retuned live.
-  const bloomComponent = addBloomComponent(world, foregroundCameraEntity, bloomDefaults);
+  const bloomComponent = addBloomComponent(
+    world,
+    foregroundCameraEntity,
+    bloomDefaults,
+  );
 
   onBloomReady?.(bloomComponent);
 
@@ -144,13 +149,7 @@ export const createSpaceShooterGame = async (
       return;
     }
 
-    const canvasMinDimension = Math.min(
-      renderContext.canvas.width,
-      renderContext.canvas.height,
-    );
-
-    shakeComponent.intensity =
-      explosionShakeIntensityFraction * canvasMinDimension;
+    shakeComponent.intensity = explosionShakeIntensityPixels;
     shakeComponent.durationSeconds = explosionShakeDurationSeconds;
     shakeComponent.elapsedSeconds = 0;
     shakeComponent.nextOffsetChangeSeconds = 0;
@@ -202,7 +201,7 @@ export const createSpaceShooterGame = async (
   });
 
   const respawnPlayer = (): void => {
-    spawnPlayer(renderContext, world, renderLayers.foreground, playerSprites);
+    spawnPlayer(world, renderLayers.foreground, playerSprites);
   };
 
   const onPlayerDeath = (): void => {
@@ -234,7 +233,7 @@ export const createSpaceShooterGame = async (
   world.addSystem(createGunEcsSystem(time, world, shootInput));
   world.addSystem(createBulletEcsSystem(time));
   world.addSystem(createAsteroidSpawnerEcsSystem(time, random));
-  world.addSystem(createAsteroidEcsSystem(time, renderContext));
+  world.addSystem(createAsteroidEcsSystem(time));
   world.addSystem(
     createSpriteAnimationEcsSystem(time, explosionSpawner.animationRegistry),
   );

--- a/documentation-site/src/pages/demos/space-shooter/_create-player.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_create-player.ts
@@ -81,7 +81,6 @@ export async function loadPlayerSprites(
  * Creates the player entity using already-loaded sprites.
  */
 export function spawnPlayer(
-  renderContext: RenderContext,
   world: EcsWorld,
   renderLayer: number,
   playerSprites: PlayerSprites,
@@ -96,8 +95,9 @@ export function spawnPlayer(
   const playerRadius =
     (playerSprite.width * playerScale + playerSprite.height * playerScale) / 4;
 
-  const halfCanvasWidth = renderContext.canvas.width / 2;
-  const halfCanvasHeight = renderContext.canvas.height / 2;
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const halfCanvasWidth = 1920 / 2;
+  const halfCanvasHeight = 1080 / 2;
 
   addSpriteComponent(world, playerEntity, playerSprite);
   addPositionComponent(world, playerEntity, {
@@ -147,7 +147,7 @@ export async function createPlayer(
 ): Promise<PlayerSprites> {
   const playerSprites = await loadPlayerSprites(renderContext, renderLayer);
 
-  spawnPlayer(renderContext, world, renderLayer, playerSprites);
+  spawnPlayer(world, renderLayer, playerSprites);
 
   return playerSprites;
 }

--- a/documentation-site/src/pages/demos/stress-test/_create-sprite-spawner.ts
+++ b/documentation-site/src/pages/demos/stress-test/_create-sprite-spawner.ts
@@ -30,7 +30,9 @@ export async function createSpriteSpawner(
 
   const sprite = createImageSprite(image, renderContext, renderLayer);
 
-  const { width, height } = renderContext.canvas;
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const halfWidth = width / 2;
   const halfHeight = height / 2;
 

--- a/documentation-site/src/pages/demos/torque/_create-game.ts
+++ b/documentation-site/src/pages/demos/torque/_create-game.ts
@@ -50,7 +50,9 @@ export const createTorqueGame = async (): Promise<Game> => {
     new KeyboardHoldBinding(thrustInput, keyCodes.space),
   );
 
-  const { width, height } = renderContext.canvas;
+  // The demo is designed for a fixed 1920x1080 canvas.
+  const width = 1920;
+  const height = 1080;
   const columnWidth = width / 2;
 
   await createThrusterScenario(


### PR DESCRIPTION
## Summary

- Documentation-site demos previously computed entity positions, spawn bounds, and layout math as ratios of `renderContext.canvas.width` / `renderContext.canvas.height`, so a demo's layout scaled with whatever container size it happened to render at.
- Replaced those ratio calculations with absolute pixel values authored against a fixed 1920x1080 canvas, across 12 demos (torque, revolute-joint, prismatic-joint, linear-spring-damper, physics, stress-test, easing-functions, nine-slice, newtons-cradle, brick-breaker, particles, space-shooter).
- Demos are intentionally no longer expected to look correct at other canvas resolutions.
- Left two categories of canvas-size reads untouched, since they're not "entity in the world" placement: mouse/pointer-to-world coordinate conversion (`screenToWorldSpace`, needs the live canvas size to map real cursor positions), and GPU render-target sizing for the space-shooter demo's bloom/blur post-processing (must match the actual rendered surface).
- Simplified `nine-slice`'s panel spacing, which previously clamped itself to fit a "narrow container" — no longer needed now that the canvas size is a fixed assumption.
- Dropped the now-unused `renderContext` parameter from `spawnPlayer` and `createAsteroidEcsSystem` in the space-shooter demo, since their only use of it was the canvas-size read that's now a constant.
- Updated `AGENTS.md`'s "Documentation Site Demos" section to document the 1920x1080 convention and its two exceptions for future changes.

## Test plan

- [x] `npm run check-types`, `npm test`, `npm run lint`, `npm run cspell`, `npm run check-exports` all pass at the repo root
- [x] `npm run build` (root) to refresh `/dist`
- [x] `documentation-site`: `npm run typecheck` and `npm run build` pass
- [x] Started the docs site locally and loaded all 12 changed demos with the canvas forced to a genuine 1920x1080 size — confirmed entities render in their intended positions with no console errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01FG27RSJkn29E1cA6UnmhDk)_