### PR TITLE
chore(deps): remove unused Rive peer dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -704,7 +704,7 @@ accident.
 
 ### Dependencies
 
-- Peer dependencies: `@rive-app/webgl2`, `howler`
+- Peer dependencies: `howler`
 - Keep dependencies minimal and well-maintained
 
 ## Additional Resources

--- a/README.md
+++ b/README.md
@@ -61,5 +61,4 @@ You can make a separate folder or package outside of the engine.
 
 - [Howler.js](https://howlerjs.com/)
 - [Vite](https://vite.dev/)
-- [Rive](https://rive.app/)
 - [Kenny](https://www.kenney.nl/)

--- a/documentation-site/package-lock.json
+++ b/documentation-site/package-lock.json
@@ -38,7 +38,7 @@
     },
     "..": {
       "name": "@forge-game-engine/forge",
-      "version": "0.22.2",
+      "version": "0.23.1",
       "license": "MIT",
       "dependencies": {
         "@types/imurmurhash": "^0.1.4",
@@ -50,7 +50,9 @@
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "1.56.0",
         "@types/howler": "^2.2.13",
+        "@types/node": "^22.10.0",
         "@types/seedrandom": "^3.0.8",
         "@vitest/ui": "^4.0.6",
         "cspell": "^10.0.1",
@@ -72,7 +74,6 @@
         "vitest": "^4.1.10"
       },
       "peerDependencies": {
-        "@rive-app/webgl2": "^2.30.1",
         "howler": "^2.2.4"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "vitest": "^4.1.10"
       },
       "peerDependencies": {
-        "@rive-app/webgl2": "^2.30.1",
         "howler": "^2.2.4"
       }
     },
@@ -1792,13 +1791,6 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rive-app/webgl2": {
-      "version": "2.37.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.1.tgz",
-      "integrity": "sha512-ll7HBYQfhxKUPYspJpICajIrPfPyg63rj3obqulRjwrzlmwXljoOl8CQgUofZi/pNM1Cfz3Und+nB8irK8tuQg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "@rive-app/webgl2": "^2.30.1",
     "howler": "^2.2.4"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Removes `@rive-app/webgl2` from `peerDependencies` in `package.json` (and regenerates `package-lock.json` / `documentation-site/package-lock.json` accordingly)
- Removes the Rive mention from the README's Acknowledgements section and from AGENTS.md's peer dependencies list

Rive was never actually imported or used anywhere in `/src` — it was only declared as a peer dependency and mentioned in the docs, so this is a clean removal with no behavior change.

No `CHANGELOG.md` entry was added since this is a `chore` (dependency cleanup), which is excluded from changelog requirements per AGENTS.md.

## Test plan

- [x] `npm run check-types` — passes (pre-existing unrelated `TS5107` deprecation warning present on `dev` too)
- [x] `npm test` — 1062 tests passed
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run cspell` — 0 issues
- [x] `npm run build` && `npm run check-exports` — passes
- [x] Confirmed no remaining references to Rive/`@rive-app` anywhere in `/src`, `/documentation-site/docs`, or demo code

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxzgPbD924gjRWm8i616xr)_