### PR TITLE
test(e2e): add real-browser input suite for keyboard, mouse, and gamepad

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,33 +477,6 @@ If you add a pixel-reading assertion:
   See the `write-e2e-test` skill and `measureGreenSquareBounds()` in
   `camera-pan-zoom.ts` for the full pattern and rationale.
 
-**Testing a polled input source (`GamepadInputSource`) needs a fake
-device, and careful step accounting.** Playwright/CDP has no gamepad
-emulation and CI has no real controller, so `gamepad-input.ts` overrides
-`navigator.getGamepads` (via `Object.defineProperty`, before constructing
-`GamepadInputSource`) to return a fake `Gamepad` whose `axes` array a test
-hook mutates directly - this models Chrome's real behavior of updating the
-`Gamepad` object in place, which is what lets `GamepadInputSource.update()`
-see new values on its next poll. Unlike `KeyboardInputSource`/
-`MouseInputSource`, which only dispatch on a real DOM event,
-`GamepadInputSource` polls every frame and only re-dispatches when *its
-own* reading changed since the previous poll (see its class doc comment) -
-so an extra, unaccounted-for `step()` changes which frame a
-value-dependent assertion lands on. `camera-pan-zoom.spec.ts`'s
-`captureState` pattern (steps once *and* reads in the same helper) is safe
-for event-driven sources but wrong for a polled one: `gamepad-input.spec.ts`
-splits it into a `step()` and a separate no-step `readState()`, called 1:1
-by every test, so it's always explicit how many polls have happened. This
-is also what makes `actionResetTypes.zero` on a gamepad-driven action
-actively wrong (not just imprecise, like it is for a held key): the
-default reset zeroes the value every frame, but the source won't re-notice
-and re-dispatch until the stick's *raw* reading itself changes, so the
-action reads correctly for exactly one frame and then stays stuck at `0`
-even while the stick stays deflected - `actionResetTypes.noReset` is
-required, per `gamepad.md`'s "Gotchas". `gamepad-input.spec.ts` asserts
-this "stuck" behavior directly, alongside a correctly-configured
-`noReset` binding, as a regression test for the documented pitfall.
-
 ### Running
 
 - `npm run test:e2e` / `npm run test:e2e:ui` - runs the suite (the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,33 @@ If you add a pixel-reading assertion:
   See the `write-e2e-test` skill and `measureGreenSquareBounds()` in
   `camera-pan-zoom.ts` for the full pattern and rationale.
 
+**Testing a polled input source (`GamepadInputSource`) needs a fake
+device, and careful step accounting.** Playwright/CDP has no gamepad
+emulation and CI has no real controller, so `gamepad-input.ts` overrides
+`navigator.getGamepads` (via `Object.defineProperty`, before constructing
+`GamepadInputSource`) to return a fake `Gamepad` whose `axes` array a test
+hook mutates directly - this models Chrome's real behavior of updating the
+`Gamepad` object in place, which is what lets `GamepadInputSource.update()`
+see new values on its next poll. Unlike `KeyboardInputSource`/
+`MouseInputSource`, which only dispatch on a real DOM event,
+`GamepadInputSource` polls every frame and only re-dispatches when *its
+own* reading changed since the previous poll (see its class doc comment) -
+so an extra, unaccounted-for `step()` changes which frame a
+value-dependent assertion lands on. `camera-pan-zoom.spec.ts`'s
+`captureState` pattern (steps once *and* reads in the same helper) is safe
+for event-driven sources but wrong for a polled one: `gamepad-input.spec.ts`
+splits it into a `step()` and a separate no-step `readState()`, called 1:1
+by every test, so it's always explicit how many polls have happened. This
+is also what makes `actionResetTypes.zero` on a gamepad-driven action
+actively wrong (not just imprecise, like it is for a held key): the
+default reset zeroes the value every frame, but the source won't re-notice
+and re-dispatch until the stick's *raw* reading itself changes, so the
+action reads correctly for exactly one frame and then stays stuck at `0`
+even while the stick stays deflected - `actionResetTypes.noReset` is
+required, per `gamepad.md`'s "Gotchas". `gamepad-input.spec.ts` asserts
+this "stuck" behavior directly, alongside a correctly-configured
+`noReset` binding, as a regression test for the documented pitfall.
+
 ### Running
 
 - `npm run test:e2e` / `npm run test:e2e:ui` - runs the suite (the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **rendering:** Cameras now show a fixed number of vertical world units (`verticalWorldUnits`, default `10`) regardless of screen resolution or aspect ratio, replacing the old implicit 1-world-unit-equals-1-pixel behavior. This is a behavior change: existing sprite and physics sizes will render at a different scale until re-tuned to the new default
 
+#### Fixed
+
+- **input:** Fix `MouseInputSource` triggering `TriggerAction` bindings regardless of the active input group, ignoring `InputManager`'s active-group gating that `KeyboardInputSource` and every other action type already respect
+
 ## [0.23.1] - 2026-07-24
 
 #### Fixed

--- a/e2e/fixtures/scenes/gamepad-input.ts
+++ b/e2e/fixtures/scenes/gamepad-input.ts
@@ -1,0 +1,302 @@
+import {
+  actionResetTypes,
+  Axis1dAction,
+  Color,
+  createCamera,
+  createCanvas,
+  createImageSprite,
+  createPresentEcsSystem,
+  createRenderContext,
+  createRenderEcsSystem,
+  createTransformEcsSystem,
+  EcsSystem,
+  EcsWorld,
+  gamepadAxes,
+  GamepadAxis1dBinding,
+  GamepadInputSource,
+  PositionEcsComponent,
+  positionId,
+  registerInputs,
+  SpriteEcsComponent,
+  spriteId,
+  Time,
+  Vector2,
+} from '../../../src/index.js';
+import { createWhiteSquareImage } from './create-white-square-image.js';
+import { inputSceneColors } from './input-scene-colors.js';
+import {
+  matchesColor,
+  PixelBounds,
+  scanPixelBounds,
+} from './input-scene-helpers.js';
+import { CreateScene, SceneHandle } from './scene.js';
+
+const defaultStepDeltaMilliseconds = 16.6666;
+const squareSize = 60;
+// How far, in world units, a square travels from its base position for a
+// full +-1 stick deflection. Kept well within the canvas's +-400 world-unit
+// half-width (canvas.height == verticalWorldUnits, canvas is 800 wide) even
+// at full deflection from a centered base position, so a square never
+// swings off-screen.
+const stickRangeInWorldUnits = 250;
+
+/** Converts a plain 0-255 RGB triple (see `input-scene-colors.ts`) to a `Color`. */
+function toColor(rgb: { r: number; g: number; b: number }): Color {
+  return new Color(rgb.r / 255, rgb.g / 255, rgb.b / 255, 1);
+}
+
+/**
+ * Installs a fake single-axis gamepad at index `0` and overrides
+ * `navigator.getGamepads` to return it, since Playwright/CDP has no
+ * built-in gamepad emulation and CI has no real controller attached. The
+ * override must run *before* `GamepadInputSource` is constructed, since it
+ * resolves its gamepad from `navigator.getGamepads()` synchronously in its
+ * constructor (to pick up a gamepad that was already "connected" before the
+ * source existed). The returned setter mutates the same `axes` array
+ * `GamepadInputSource.update()` re-reads every frame via
+ * `navigator.getGamepads()[index]`, modeling Chrome's real behavior of
+ * updating the `Gamepad` object in place (see `GamepadInputSource`'s own
+ * doc comment on why it re-fetches every frame instead of caching it).
+ * @returns A setter for the fake gamepad's analog stick axes.
+ */
+function installFakeGamepad(): {
+  setAxis(index: number, value: number): void;
+} {
+  const axes = [0, 0, 0, 0];
+
+  const fakeGamepad = {
+    id: 'forge-e2e-fake-gamepad',
+    index: 0,
+    connected: true,
+    timestamp: 0,
+    mapping: 'standard',
+    axes,
+    buttons: [],
+  } as unknown as Gamepad;
+
+  Object.defineProperty(navigator, 'getGamepads', {
+    value: (): (Gamepad | null)[] => [fakeGamepad],
+    configurable: true,
+  });
+
+  return {
+    setAxis(index: number, value: number): void {
+      axes[index] = value;
+    },
+  };
+}
+
+/** The handle `gamepad-input.spec.ts` drives and asserts against. */
+export interface GamepadInputSceneHandle extends SceneHandle {
+  /** The correctly-configured (`noReset`) stick square's local position. */
+  readonly stickPosition: { x: number; y: number };
+  /** The incorrectly-configured (default `zero` reset) stick square's local position. */
+  readonly brokenStickPosition: { x: number; y: number };
+  /** The `'menu'`-group stick square's local position. */
+  readonly menuStickPosition: { x: number; y: number };
+  /** Sets the fake gamepad's left stick X axis, in `[-1, 1]`. */
+  setStickX(value: number): void;
+  /** Sets the `InputManager`'s active input group. */
+  setActiveGroup(group: string | null): void;
+  /**
+   * Scans the rendered canvas for pixels matching `targetRgb` (see
+   * `input-scene-colors.ts`) and returns their bounding box, or `null` if
+   * none are found. Must be called in the same `page.evaluate` task as the
+   * preceding `step()` - see `SceneHandle.step`.
+   */
+  measureBounds(targetRgb: {
+    r: number;
+    g: number;
+    b: number;
+  }): PixelBounds | null;
+}
+
+/**
+ * Builds a scene exercising `GamepadInputSource` against a fake, polled
+ * gamepad (see `installFakeGamepad`): a correctly-configured
+ * `actionResetTypes.noReset` stick axis that moves continuously while
+ * deflected (and ignores small deadzone drift), a second stick axis left at
+ * the default `actionResetTypes.zero` to demonstrate the documented pitfall
+ * (`gamepad.md`'s "Gotchas") of combining a polled source's
+ * only-dispatch-on-change optimization with a reset type that zeroes the
+ * action every frame - the value reads correctly for exactly one frame,
+ * then gets stuck at `0` even though the stick stays deflected - and a
+ * third stick binding on a `'menu'`-group action, to prove `InputManager`'s
+ * active-group gating applies to a polled source the same way it does to
+ * event-driven keyboard/mouse sources.
+ * @param container - The element to render the scene's canvas into.
+ * @returns The scene's handle.
+ */
+export const createScene: CreateScene = async (
+  container: HTMLElement,
+): Promise<GamepadInputSceneHandle> => {
+  const fakeGamepad = installFakeGamepad();
+
+  const time = new Time();
+  const world = new EcsWorld();
+  const canvas = createCanvas(container);
+  const renderContext = createRenderContext(canvas, {
+    preserveDrawingBuffer: true,
+  });
+
+  const stickAction = new Axis1dAction(
+    'stick',
+    'game',
+    actionResetTypes.noReset,
+  );
+  // Default `actionResetTypes.zero`, deliberately - see the scene doc
+  // comment above for the "stuck at zero" pitfall this demonstrates.
+  const brokenStickAction = new Axis1dAction('brokenStick', 'game');
+  const menuStickAction = new Axis1dAction(
+    'menuStick',
+    'menu',
+    actionResetTypes.noReset,
+  );
+
+  const inputManager = registerInputs(world, time, {
+    axis1dActions: [stickAction, brokenStickAction, menuStickAction],
+  });
+
+  const gamepadInputSource = new GamepadInputSource(inputManager);
+
+  gamepadInputSource.axis1dBindings.add(
+    new GamepadAxis1dBinding(stickAction, {
+      axisIndex: gamepadAxes.leftStickX,
+    }),
+  );
+  gamepadInputSource.axis1dBindings.add(
+    new GamepadAxis1dBinding(brokenStickAction, {
+      axisIndex: gamepadAxes.leftStickX,
+    }),
+  );
+  gamepadInputSource.axis1dBindings.add(
+    new GamepadAxis1dBinding(menuStickAction, {
+      axisIndex: gamepadAxes.leftStickX,
+    }),
+  );
+
+  const cameraEntity = createCamera(world, {
+    isStatic: true,
+    clearColor: toColor(inputSceneColors.clear),
+    // 1 world unit == 1 screen pixel, see camera-pan-zoom.ts's identical use.
+    verticalWorldUnits: canvas.height,
+  });
+
+  const squareImage = await createWhiteSquareImage();
+  const squareSprite = createImageSprite(squareImage, renderContext, 1);
+
+  function createSquare(
+    x: number,
+    y: number,
+    color: Color,
+  ): { position: PositionEcsComponent; sprite: SpriteEcsComponent } {
+    const entity = world.createEntity();
+
+    const position = world.addComponent(entity, positionId, {
+      local: new Vector2(x, y),
+      world: new Vector2(x, y),
+    });
+
+    const sprite = world.addComponent(entity, spriteId, {
+      ...squareSprite,
+      width: squareSize,
+      height: squareSize,
+      tintColor: color,
+    });
+
+    return { position, sprite };
+  }
+
+  const stickBase = { x: 0, y: -200 };
+  const brokenBase = { x: 0, y: 0 };
+  const menuStickBase = { x: 0, y: 200 };
+
+  const stick = createSquare(
+    stickBase.x,
+    stickBase.y,
+    toColor(inputSceneColors.blue),
+  );
+  const broken = createSquare(
+    brokenBase.x,
+    brokenBase.y,
+    toColor(inputSceneColors.yellow),
+  );
+  const menuStick = createSquare(
+    menuStickBase.x,
+    menuStickBase.y,
+    toColor(inputSceneColors.cyan),
+  );
+
+  // A single system, anchored on the camera entity (query: [positionId]
+  // matches it too) so it runs exactly once per tick regardless of how many
+  // squares exist. Registered at the default `normal` priority, it runs
+  // after `registerInputs`'s early input-update system - which polls
+  // `GamepadInputSource.update()` - and before its late reset-inputs
+  // system, the same ordering `createCameraEcsSystem` relies on for
+  // pan/zoom input.
+  //
+  // Each square's offset from its base position is a direct mapping of its
+  // action's *current* value (like a joystick-controlled reticle), not an
+  // accumulation, so a square's position always reflects exactly what its
+  // action currently holds - including staying frozen at its base position
+  // once "stuck at zero" (see `brokenStickAction`), or at its last position
+  // once group-gated (see `menuStickAction`), instead of drifting.
+  const inputConsumerSystem: EcsSystem<[PositionEcsComponent]> = {
+    query: [positionId],
+    run: (result) => {
+      if (result.entity !== cameraEntity) {
+        return;
+      }
+
+      stick.position.local.x =
+        stickBase.x + stickAction.value * stickRangeInWorldUnits;
+      broken.position.local.x =
+        brokenBase.x + brokenStickAction.value * stickRangeInWorldUnits;
+      menuStick.position.local.x =
+        menuStickBase.x + menuStickAction.value * stickRangeInWorldUnits;
+    },
+  };
+
+  world.addSystem(inputConsumerSystem);
+  world.addSystem(createTransformEcsSystem());
+  world.addSystem(createRenderEcsSystem(renderContext));
+  world.addSystem(createPresentEcsSystem(renderContext));
+
+  let clockInMilliseconds = 0;
+
+  return {
+    step(deltaMilliseconds: number = defaultStepDeltaMilliseconds): void {
+      clockInMilliseconds += deltaMilliseconds;
+      time.update(clockInMilliseconds);
+      world.update();
+    },
+
+    get stickPosition(): { x: number; y: number } {
+      return { x: stick.position.local.x, y: stick.position.local.y };
+    },
+
+    get brokenStickPosition(): { x: number; y: number } {
+      return { x: broken.position.local.x, y: broken.position.local.y };
+    },
+
+    get menuStickPosition(): { x: number; y: number } {
+      return { x: menuStick.position.local.x, y: menuStick.position.local.y };
+    },
+
+    setStickX(value: number): void {
+      fakeGamepad.setAxis(gamepadAxes.leftStickX, value);
+    },
+
+    setActiveGroup(group: string | null): void {
+      inputManager.setActiveGroup(group);
+    },
+
+    measureBounds(targetRgb: {
+      r: number;
+      g: number;
+      b: number;
+    }): PixelBounds | null {
+      return scanPixelBounds(canvas, matchesColor(targetRgb));
+    },
+  };
+};

--- a/e2e/fixtures/scenes/input-scene-colors.ts
+++ b/e2e/fixtures/scenes/input-scene-colors.ts
@@ -1,0 +1,19 @@
+/**
+ * Plain 0-255 RGB constants for the input scenes' landmark sprites, kept
+ * free of any `/src` import (see `camera-pan-zoom-clear-color.ts` for why:
+ * specs run under Node, which can't parse `/src`'s `.glsl` shader imports).
+ * Scenes build the matching `Color` (0-1 float) instances themselves; specs
+ * use these directly with `matchesColor` from `input-scene-helpers.ts`.
+ * Chosen to be maximally distinct from each other and from `clearColorRgb`
+ * so `matchesColor`'s tolerance never confuses one landmark for another.
+ */
+export const inputSceneColors = {
+  clear: { r: 20, g: 20, b: 20 },
+  red: { r: 255, g: 0, b: 0 },
+  green: { r: 0, g: 255, b: 0 },
+  blue: { r: 0, g: 0, b: 255 },
+  yellow: { r: 255, g: 255, b: 0 },
+  orange: { r: 255, g: 140, b: 0 },
+  magenta: { r: 255, g: 0, b: 255 },
+  cyan: { r: 0, g: 255, b: 255 },
+} as const;

--- a/e2e/fixtures/scenes/input-scene-helpers.ts
+++ b/e2e/fixtures/scenes/input-scene-helpers.ts
@@ -1,0 +1,122 @@
+/**
+ * A landmark sprite's on-screen bounding box, as measured from the actual
+ * rendered canvas bitmap (not from ECS state).
+ */
+export interface PixelBounds {
+  /** The leftmost on-screen x pixel where a matching pixel was found. */
+  left: number;
+  /** The rightmost on-screen x pixel where a matching pixel was found. */
+  right: number;
+  /** The topmost on-screen y pixel where a matching pixel was found. */
+  top: number;
+  /** The bottommost on-screen y pixel where a matching pixel was found. */
+  bottom: number;
+}
+
+/**
+ * Accumulates a bounding box over a stream of matched (x, y) pixel
+ * coordinates, pulled out of `scanPixelBounds` to keep that function's
+ * cognitive complexity down.
+ */
+class PixelBoundsAccumulator {
+  private _left = -1;
+  private _right = -1;
+  private _top = -1;
+  private _bottom = -1;
+
+  public include(x: number, y: number): void {
+    this._left = this._left === -1 ? x : Math.min(this._left, x);
+    this._right = Math.max(this._right, x);
+    this._top = this._top === -1 ? y : Math.min(this._top, y);
+    this._bottom = Math.max(this._bottom, y);
+  }
+
+  public toBounds(): PixelBounds | null {
+    if (this._left === -1) {
+      return null;
+    }
+
+    return {
+      left: this._left,
+      right: this._right,
+      top: this._top,
+      bottom: this._bottom,
+    };
+  }
+}
+
+/**
+ * Scans the *actual displayed bitmap* of `canvas` (via a `drawImage`/
+ * `getImageData` readback - see AGENTS.md's "Be wary of pixel-level
+ * rendering assertions") for pixels matching `isMatch`, and returns their
+ * combined bounding box. Returns `null` if no matching pixel is found. This
+ * generalizes `camera-pan-zoom.ts`'s `measureGreenSquareBounds` to scan the
+ * full canvas (not just one horizontal line) and to accept an arbitrary
+ * color predicate, since the input scenes need to locate landmarks that can
+ * move both horizontally and vertically. Must be called in the same
+ * `page.evaluate` task as the `step()` call that precedes it, for the same
+ * reason documented there: the canvas isn't created with
+ * `preserveDrawingBuffer`, so a browser may clear it as soon as control
+ * returns to Playwright after a frame is presented.
+ * @param canvas - The canvas to read pixels back from.
+ * @param isMatch - Called with each pixel's 0-255 RGB components.
+ * @returns The matching pixels' bounding box, or `null` if none matched.
+ */
+export function scanPixelBounds(
+  canvas: HTMLCanvasElement,
+  isMatch: (r: number, g: number, b: number) => boolean,
+): PixelBounds | null {
+  const sampleCanvas = document.createElement('canvas');
+
+  sampleCanvas.width = canvas.width;
+  sampleCanvas.height = canvas.height;
+
+  const context2d = sampleCanvas.getContext('2d');
+
+  if (!context2d) {
+    throw new Error('2D canvas context not available');
+  }
+
+  context2d.drawImage(canvas, 0, 0);
+
+  const { data } = context2d.getImageData(0, 0, canvas.width, canvas.height);
+  const bounds = new PixelBoundsAccumulator();
+
+  for (let y = 0; y < canvas.height; y++) {
+    for (let x = 0; x < canvas.width; x++) {
+      const offset = (y * canvas.width + x) * 4;
+
+      if (isMatch(data[offset], data[offset + 1], data[offset + 2])) {
+        bounds.include(x, y);
+      }
+    }
+  }
+
+  return bounds.toBounds();
+}
+
+/**
+ * Generous per-channel tolerance for matching a tint color against a
+ * rendered pixel: pixel quantization and antialiased edges mean an exact
+ * byte match isn't realistic, and this only needs to distinguish between a
+ * handful of maximally-distinct tint colors (see `input-scene-colors.ts`),
+ * not match an exact value.
+ */
+const colorMatchTolerance = 40;
+
+/**
+ * Builds a pixel-match predicate (for `scanPixelBounds`) that matches a
+ * given 0-255 RGB target color within `colorMatchTolerance`.
+ * @param target - The target color's 0-255 RGB components.
+ * @returns A predicate suitable for `scanPixelBounds`.
+ */
+export function matchesColor(target: {
+  r: number;
+  g: number;
+  b: number;
+}): (r: number, g: number, b: number) => boolean {
+  return (r: number, g: number, b: number): boolean =>
+    Math.abs(r - target.r) < colorMatchTolerance &&
+    Math.abs(g - target.g) < colorMatchTolerance &&
+    Math.abs(b - target.b) < colorMatchTolerance;
+}

--- a/e2e/fixtures/scenes/keyboard-input.ts
+++ b/e2e/fixtures/scenes/keyboard-input.ts
@@ -1,0 +1,293 @@
+import {
+  actionResetTypes,
+  Axis1dAction,
+  Axis2dAction,
+  buttonMoments,
+  Color,
+  createCamera,
+  createCanvas,
+  createImageSprite,
+  createPresentEcsSystem,
+  createRenderContext,
+  createRenderEcsSystem,
+  createTransformEcsSystem,
+  EcsSystem,
+  EcsWorld,
+  HoldAction,
+  KeyboardAxis1dBinding,
+  KeyboardAxis2dBinding,
+  KeyboardHoldBinding,
+  KeyboardInputSource,
+  KeyboardTriggerBinding,
+  keyCodes,
+  PositionEcsComponent,
+  positionId,
+  registerInputs,
+  SpriteEcsComponent,
+  spriteId,
+  Time,
+  TriggerAction,
+  Vector2,
+} from '../../../src/index.js';
+import { createWhiteSquareImage } from './create-white-square-image.js';
+import {
+  matchesColor,
+  PixelBounds,
+  scanPixelBounds,
+} from './input-scene-helpers.js';
+import { inputSceneColors } from './input-scene-colors.js';
+import { CreateScene, SceneHandle } from './scene.js';
+
+const defaultStepDeltaMilliseconds = 16.6666;
+const squareSize = 60;
+const moveSpeedInWorldUnitsPerSecond = 200;
+// How far, in world units, a single non-zero `impulseAction.value` frame
+// moves the impulse square - see the scene doc comment for why this only
+// ever applies for exactly one frame per key press/release.
+const impulseStepInWorldUnits = 80;
+const holdSmallSize = 40;
+const holdBigSize = 90;
+
+/** Converts a plain 0-255 RGB triple (see `input-scene-colors.ts`) to a `Color`. */
+function toColor(rgb: { r: number; g: number; b: number }): Color {
+  return new Color(rgb.r / 255, rgb.g / 255, rgb.b / 255, 1);
+}
+
+/** The handle `keyboard-input.spec.ts` drives and asserts against. */
+export interface KeyboardInputSceneHandle extends SceneHandle {
+  /** The WASD-driven square's local position (`Axis2dAction`, `noReset`). */
+  readonly moverPosition: { x: number; y: number };
+  /** The arrow-key-driven square's local position (`Axis1dAction`, default `zero` reset). */
+  readonly impulsePosition: { x: number; y: number };
+  /** How many times the `'game'`-group jump `TriggerAction` has fired. */
+  readonly gameTriggerCount: number;
+  /** How many times the `'menu'`-group confirm `TriggerAction` has fired. */
+  readonly menuTriggerCount: number;
+  /** Whether the `HoldAction` bound to `KeyC` is currently held. */
+  readonly isCrouching: boolean;
+  /** Sets the `InputManager`'s active input group. */
+  setActiveGroup(group: string | null): void;
+  /**
+   * Scans the rendered canvas for pixels matching `targetRgb` (see
+   * `input-scene-colors.ts`) and returns their bounding box, or `null` if
+   * none are found. Must be called in the same `page.evaluate` task as the
+   * preceding `step()` - see `SceneHandle.step`.
+   */
+  measureBounds(targetRgb: {
+    r: number;
+    g: number;
+    b: number;
+  }): PixelBounds | null;
+}
+
+/**
+ * Builds a scene exercising every keyboard-bound action type against real
+ * `KeyboardEvent`s: a WASD-driven `Axis2dAction` (continuous movement, via
+ * `actionResetTypes.noReset`), an arrow-key-driven `Axis1dAction` (the
+ * default `actionResetTypes.zero`, deliberately - see the impulse square's
+ * comment below), a `TriggerAction` on Space, a `HoldAction` on `KeyC`, and
+ * a second `TriggerAction` bound to the *same* Space key but a different
+ * (`'menu'`) input group, to prove `InputManager`'s active-group gating
+ * actually gates dispatch rather than just binding lookup.
+ * @param container - The element to render the scene's canvas into.
+ * @returns The scene's handle.
+ */
+export const createScene: CreateScene = async (
+  container: HTMLElement,
+): Promise<KeyboardInputSceneHandle> => {
+  const time = new Time();
+  const world = new EcsWorld();
+  const canvas = createCanvas(container);
+  const renderContext = createRenderContext(canvas, {
+    preserveDrawingBuffer: true,
+  });
+
+  const moveAction = new Axis2dAction('move', 'game', actionResetTypes.noReset);
+  // Default `actionResetTypes.zero`, on purpose: this is the scene's
+  // demonstration of the "twitchy" behavior actions.md warns about for a
+  // held key bound with the default reset type - see the spec for the
+  // exact single-impulse-then-snap-back sequence this produces.
+  const impulseAction = new Axis1dAction('impulse', 'game');
+  const jumpAction = new TriggerAction('jump', 'game');
+  const menuConfirmAction = new TriggerAction('confirm', 'menu');
+  const crouchAction = new HoldAction('crouch', 'game');
+
+  const inputManager = registerInputs(world, time, {
+    axis2dActions: [moveAction],
+    axis1dActions: [impulseAction],
+    triggerActions: [jumpAction, menuConfirmAction],
+    holdActions: [crouchAction],
+  });
+
+  const keyboardInputSource = new KeyboardInputSource(inputManager);
+
+  keyboardInputSource.axis2dBindings.add(
+    new KeyboardAxis2dBinding(
+      moveAction,
+      keyCodes.w,
+      keyCodes.s,
+      keyCodes.d,
+      keyCodes.a,
+    ),
+  );
+
+  keyboardInputSource.axis1dBindings.add(
+    new KeyboardAxis1dBinding(
+      impulseAction,
+      keyCodes.arrowRight,
+      keyCodes.arrowLeft,
+    ),
+  );
+
+  keyboardInputSource.triggerBindings.add(
+    new KeyboardTriggerBinding(jumpAction, keyCodes.space, buttonMoments.down),
+  );
+
+  // Same physical key as `jumpAction` above, deliberately - this is what
+  // proves group gating actually discards the dispatch rather than the two
+  // actions simply never colliding in practice.
+  keyboardInputSource.triggerBindings.add(
+    new KeyboardTriggerBinding(
+      menuConfirmAction,
+      keyCodes.space,
+      buttonMoments.down,
+    ),
+  );
+
+  keyboardInputSource.holdBindings.add(
+    new KeyboardHoldBinding(crouchAction, keyCodes.c),
+  );
+
+  const cameraEntity = createCamera(world, {
+    isStatic: true,
+    clearColor: toColor(inputSceneColors.clear),
+    // 1 world unit == 1 screen pixel, see camera-pan-zoom.ts's identical use.
+    verticalWorldUnits: canvas.height,
+  });
+
+  const squareImage = await createWhiteSquareImage();
+  const squareSprite = createImageSprite(squareImage, renderContext, 1);
+
+  function createSquare(
+    x: number,
+    y: number,
+    color: Color,
+  ): { position: PositionEcsComponent; sprite: SpriteEcsComponent } {
+    const entity = world.createEntity();
+
+    const position = world.addComponent(entity, positionId, {
+      local: new Vector2(x, y),
+      world: new Vector2(x, y),
+    });
+
+    const sprite = world.addComponent(entity, spriteId, {
+      ...squareSprite,
+      width: squareSize,
+      height: squareSize,
+      tintColor: color,
+    });
+
+    return { position, sprite };
+  }
+
+  const mover = createSquare(-300, -200, toColor(inputSceneColors.blue));
+  const impulse = createSquare(-300, 0, toColor(inputSceneColors.yellow));
+  const marker = createSquare(-300, 200, toColor(inputSceneColors.red));
+  const holdSquare = createSquare(300, 0, toColor(inputSceneColors.orange));
+
+  holdSquare.sprite.width = holdSmallSize;
+  holdSquare.sprite.height = holdSmallSize;
+
+  let gameTriggerCount = 0;
+  let menuTriggerCount = 0;
+
+  // A single system, anchored on the camera entity (query: [positionId]
+  // matches it too) so it runs exactly once per tick regardless of how many
+  // squares exist. Registered at the default `normal` priority, it runs
+  // after `registerInputs`'s early input-update system (so this frame's
+  // key events have already been dispatched) and before its late
+  // reset-inputs system (so `isTriggered`/axis values are still valid) -
+  // the same ordering `createCameraEcsSystem` relies on for pan/zoom input.
+  const inputConsumerSystem: EcsSystem<[PositionEcsComponent]> = {
+    query: [positionId],
+    run: (result) => {
+      if (result.entity !== cameraEntity) {
+        return;
+      }
+
+      const deltaSeconds = time.deltaTimeInMilliseconds / 1000;
+
+      mover.position.local.x +=
+        moveAction.value.x * moveSpeedInWorldUnitsPerSecond * deltaSeconds;
+      mover.position.local.y +=
+        moveAction.value.y * moveSpeedInWorldUnitsPerSecond * deltaSeconds;
+
+      impulse.position.local.x += impulseAction.value * impulseStepInWorldUnits;
+
+      if (jumpAction.isTriggered) {
+        gameTriggerCount++;
+        marker.sprite.tintColor =
+          gameTriggerCount % 2 === 0
+            ? toColor(inputSceneColors.red)
+            : toColor(inputSceneColors.green);
+      }
+
+      if (menuConfirmAction.isTriggered) {
+        menuTriggerCount++;
+        marker.sprite.tintColor = toColor(inputSceneColors.magenta);
+      }
+
+      const holdSize = crouchAction.isHeld ? holdBigSize : holdSmallSize;
+
+      holdSquare.sprite.width = holdSize;
+      holdSquare.sprite.height = holdSize;
+    },
+  };
+
+  world.addSystem(inputConsumerSystem);
+  world.addSystem(createTransformEcsSystem());
+  world.addSystem(createRenderEcsSystem(renderContext));
+  world.addSystem(createPresentEcsSystem(renderContext));
+
+  let clockInMilliseconds = 0;
+
+  return {
+    step(deltaMilliseconds: number = defaultStepDeltaMilliseconds): void {
+      clockInMilliseconds += deltaMilliseconds;
+      time.update(clockInMilliseconds);
+      world.update();
+    },
+
+    get moverPosition(): { x: number; y: number } {
+      return { x: mover.position.local.x, y: mover.position.local.y };
+    },
+
+    get impulsePosition(): { x: number; y: number } {
+      return { x: impulse.position.local.x, y: impulse.position.local.y };
+    },
+
+    get gameTriggerCount(): number {
+      return gameTriggerCount;
+    },
+
+    get menuTriggerCount(): number {
+      return menuTriggerCount;
+    },
+
+    get isCrouching(): boolean {
+      return crouchAction.isHeld;
+    },
+
+    setActiveGroup(group: string | null): void {
+      inputManager.setActiveGroup(group);
+    },
+
+    measureBounds(targetRgb: {
+      r: number;
+      g: number;
+      b: number;
+    }): PixelBounds | null {
+      return scanPixelBounds(canvas, matchesColor(targetRgb));
+    },
+  };
+};

--- a/e2e/fixtures/scenes/mouse-input.ts
+++ b/e2e/fixtures/scenes/mouse-input.ts
@@ -1,0 +1,298 @@
+import {
+  actionResetTypes,
+  Axis1dAction,
+  Axis2dAction,
+  buttonMoments,
+  Color,
+  createCamera,
+  createCanvas,
+  createImageSprite,
+  createPresentEcsSystem,
+  createRenderContext,
+  createRenderEcsSystem,
+  createTransformEcsSystem,
+  EcsSystem,
+  EcsWorld,
+  HoldAction,
+  MouseAxis1dBinding,
+  MouseAxis2dBinding,
+  mouseButtons,
+  MouseHoldBinding,
+  MouseInputSource,
+  MouseTriggerBinding,
+  PositionEcsComponent,
+  positionId,
+  registerInputs,
+  SpriteEcsComponent,
+  spriteId,
+  Time,
+  TriggerAction,
+  Vector2,
+} from '../../../src/index.js';
+import { createWhiteSquareImage } from './create-white-square-image.js';
+import { inputSceneColors } from './input-scene-colors.js';
+import {
+  matchesColor,
+  PixelBounds,
+  scanPixelBounds,
+} from './input-scene-helpers.js';
+import { CreateScene, SceneHandle } from './scene.js';
+
+const defaultStepDeltaMilliseconds = 16.6666;
+const squareSize = 60;
+// How far, in world units, the pointer square travels for a full ratio
+// swing (mouse at a canvas edge, +-0.5 from `MouseAxis2dBinding`'s default
+// center cursor origin).
+const pointerRangeInWorldUnits = 300;
+// How far, in world units, a single non-zero `scrollAction.value` frame
+// moves the scroll square - see the scene doc comment for why this only
+// ever applies for exactly one frame per wheel event.
+const scrollStepInWorldUnits = 60;
+const holdSmallSize = 40;
+const holdBigSize = 90;
+
+/** Converts a plain 0-255 RGB triple (see `input-scene-colors.ts`) to a `Color`. */
+function toColor(rgb: { r: number; g: number; b: number }): Color {
+  return new Color(rgb.r / 255, rgb.g / 255, rgb.b / 255, 1);
+}
+
+/** The handle `mouse-input.spec.ts` drives and asserts against. */
+export interface MouseInputSceneHandle extends SceneHandle {
+  /** The cursor-tracking square's local position (`Axis2dAction`, `noReset`). */
+  readonly pointerPosition: { x: number; y: number };
+  /** The wheel-driven square's local position (`Axis1dAction`, default `zero` reset). */
+  readonly scrollPosition: { x: number; y: number };
+  /** How many times the `'game'`-group select `TriggerAction` has fired. */
+  readonly gameTriggerCount: number;
+  /** How many times the `'menu'`-group confirm `TriggerAction` has fired. */
+  readonly menuTriggerCount: number;
+  /** Whether the `HoldAction` bound to the right mouse button is currently held. */
+  readonly isAiming: boolean;
+  /** Sets the `InputManager`'s active input group. */
+  setActiveGroup(group: string | null): void;
+  /**
+   * Scans the rendered canvas for pixels matching `targetRgb` (see
+   * `input-scene-colors.ts`) and returns their bounding box, or `null` if
+   * none are found. Must be called in the same `page.evaluate` task as the
+   * preceding `step()` - see `SceneHandle.step`.
+   */
+  measureBounds(targetRgb: {
+    r: number;
+    g: number;
+    b: number;
+  }): PixelBounds | null;
+}
+
+/**
+ * Builds a scene exercising every mouse-bound action type against real
+ * `MouseEvent`s: a cursor-tracking `Axis2dAction` (`actionResetTypes.noReset`,
+ * so the square keeps following the last-known cursor ratio between
+ * `mousemove` events instead of snapping back to center), a wheel-driven
+ * `Axis1dAction` (the default `actionResetTypes.zero`, appropriate here
+ * since a wheel event is a one-shot "delta this frame" input with no
+ * corresponding "up" event to reverse it), a `TriggerAction` on the left
+ * button, a `HoldAction` on the right button, and a second `TriggerAction`
+ * bound to the *same* left button but a different (`'menu'`) input group -
+ * a regression test for `MouseInputSource` previously triggering regardless
+ * of the active input group.
+ * @param container - The element to render the scene's canvas into.
+ * @returns The scene's handle.
+ */
+export const createScene: CreateScene = async (
+  container: HTMLElement,
+): Promise<MouseInputSceneHandle> => {
+  const time = new Time();
+  const world = new EcsWorld();
+  const canvas = createCanvas(container);
+  const renderContext = createRenderContext(canvas, {
+    preserveDrawingBuffer: true,
+  });
+
+  const pointerAction = new Axis2dAction(
+    'pointer',
+    'game',
+    actionResetTypes.noReset,
+  );
+  // Default `actionResetTypes.zero`, correctly here: the wheel has no "up"
+  // event to reverse a `noReset` value, so without a zero reset a single
+  // scroll tick would move the square every single frame forever.
+  const scrollAction = new Axis1dAction('scroll', 'game');
+  const selectAction = new TriggerAction('select', 'game');
+  const menuConfirmAction = new TriggerAction('confirm', 'menu');
+  const aimAction = new HoldAction('aim', 'game');
+
+  const inputManager = registerInputs(world, time, {
+    axis2dActions: [pointerAction],
+    axis1dActions: [scrollAction],
+    triggerActions: [selectAction, menuConfirmAction],
+    holdActions: [aimAction],
+  });
+
+  const mouseInputSource = new MouseInputSource(inputManager, canvas);
+
+  mouseInputSource.axis2dBindings.add(new MouseAxis2dBinding(pointerAction));
+  mouseInputSource.axis1dBindings.add(new MouseAxis1dBinding(scrollAction));
+
+  mouseInputSource.triggerBindings.add(
+    new MouseTriggerBinding(
+      selectAction,
+      mouseButtons.left,
+      buttonMoments.down,
+    ),
+  );
+
+  // Same physical button as `selectAction` above, deliberately - this is
+  // what proves group gating actually discards the dispatch rather than
+  // the two actions simply never colliding in practice.
+  mouseInputSource.triggerBindings.add(
+    new MouseTriggerBinding(
+      menuConfirmAction,
+      mouseButtons.left,
+      buttonMoments.down,
+    ),
+  );
+
+  mouseInputSource.holdBindings.add(
+    new MouseHoldBinding(aimAction, mouseButtons.right),
+  );
+
+  const cameraEntity = createCamera(world, {
+    isStatic: true,
+    clearColor: toColor(inputSceneColors.clear),
+    // 1 world unit == 1 screen pixel, see camera-pan-zoom.ts's identical use.
+    verticalWorldUnits: canvas.height,
+  });
+
+  const squareImage = await createWhiteSquareImage();
+  const squareSprite = createImageSprite(squareImage, renderContext, 1);
+
+  function createSquare(
+    x: number,
+    y: number,
+    color: Color,
+  ): { position: PositionEcsComponent; sprite: SpriteEcsComponent } {
+    const entity = world.createEntity();
+
+    const position = world.addComponent(entity, positionId, {
+      local: new Vector2(x, y),
+      world: new Vector2(x, y),
+    });
+
+    const sprite = world.addComponent(entity, spriteId, {
+      ...squareSprite,
+      width: squareSize,
+      height: squareSize,
+      tintColor: color,
+    });
+
+    return { position, sprite };
+  }
+
+  const pointerBase = { x: 0, y: -200 };
+  const pointer = createSquare(
+    pointerBase.x,
+    pointerBase.y,
+    toColor(inputSceneColors.blue),
+  );
+  const scroll = createSquare(-300, 0, toColor(inputSceneColors.yellow));
+  const marker = createSquare(-300, 200, toColor(inputSceneColors.red));
+  const holdSquare = createSquare(300, 0, toColor(inputSceneColors.orange));
+
+  holdSquare.sprite.width = holdSmallSize;
+  holdSquare.sprite.height = holdSmallSize;
+
+  let gameTriggerCount = 0;
+  let menuTriggerCount = 0;
+
+  // A single system, anchored on the camera entity (query: [positionId]
+  // matches it too) so it runs exactly once per tick regardless of how many
+  // squares exist. Registered at the default `normal` priority, it runs
+  // after `registerInputs`'s early input-update system (so this frame's
+  // mouse events have already been dispatched) and before its late
+  // reset-inputs system (so `isTriggered`/axis values are still valid) -
+  // the same ordering `createCameraEcsSystem` relies on for pan/zoom input.
+  const inputConsumerSystem: EcsSystem<[PositionEcsComponent]> = {
+    query: [positionId],
+    run: (result) => {
+      if (result.entity !== cameraEntity) {
+        return;
+      }
+
+      // A direct position mapping (not an accumulation) - `pointerAction`
+      // represents the cursor's *current* ratio offset from center, so the
+      // square should track it continuously, the same way a real cursor or
+      // reticle would.
+      pointer.position.local.x =
+        pointerBase.x + pointerAction.value.x * pointerRangeInWorldUnits;
+      pointer.position.local.y =
+        pointerBase.y + pointerAction.value.y * pointerRangeInWorldUnits;
+
+      scroll.position.local.x += scrollAction.value * scrollStepInWorldUnits;
+
+      if (selectAction.isTriggered) {
+        gameTriggerCount++;
+        marker.sprite.tintColor =
+          gameTriggerCount % 2 === 0
+            ? toColor(inputSceneColors.red)
+            : toColor(inputSceneColors.green);
+      }
+
+      if (menuConfirmAction.isTriggered) {
+        menuTriggerCount++;
+        marker.sprite.tintColor = toColor(inputSceneColors.magenta);
+      }
+
+      const holdSize = aimAction.isHeld ? holdBigSize : holdSmallSize;
+
+      holdSquare.sprite.width = holdSize;
+      holdSquare.sprite.height = holdSize;
+    },
+  };
+
+  world.addSystem(inputConsumerSystem);
+  world.addSystem(createTransformEcsSystem());
+  world.addSystem(createRenderEcsSystem(renderContext));
+  world.addSystem(createPresentEcsSystem(renderContext));
+
+  let clockInMilliseconds = 0;
+
+  return {
+    step(deltaMilliseconds: number = defaultStepDeltaMilliseconds): void {
+      clockInMilliseconds += deltaMilliseconds;
+      time.update(clockInMilliseconds);
+      world.update();
+    },
+
+    get pointerPosition(): { x: number; y: number } {
+      return { x: pointer.position.local.x, y: pointer.position.local.y };
+    },
+
+    get scrollPosition(): { x: number; y: number } {
+      return { x: scroll.position.local.x, y: scroll.position.local.y };
+    },
+
+    get gameTriggerCount(): number {
+      return gameTriggerCount;
+    },
+
+    get menuTriggerCount(): number {
+      return menuTriggerCount;
+    },
+
+    get isAiming(): boolean {
+      return aimAction.isHeld;
+    },
+
+    setActiveGroup(group: string | null): void {
+      inputManager.setActiveGroup(group);
+    },
+
+    measureBounds(targetRgb: {
+      r: number;
+      g: number;
+      b: number;
+    }): PixelBounds | null {
+      return scanPixelBounds(canvas, matchesColor(targetRgb));
+    },
+  };
+};

--- a/e2e/specs/gamepad-input.spec.ts
+++ b/e2e/specs/gamepad-input.spec.ts
@@ -1,0 +1,284 @@
+import { expect, test } from '@playwright/test';
+import { inputSceneColors } from '../fixtures/scenes/input-scene-colors.js';
+import type { GamepadInputSceneHandle } from '../fixtures/scenes/gamepad-input.js';
+
+// `window.__forgeTestHooks` is declared globally (as the base `SceneHandle`)
+// by `harness.ts`. Each `page.evaluate` callback below narrows it to this
+// spec's own scene handle type inline - see camera-pan-zoom.spec.ts's `Hooks`
+// comment for why.
+type Hooks = GamepadInputSceneHandle;
+type Page = import('@playwright/test').Page;
+
+// Unlike the keyboard/mouse specs' `captureState`, this one does *not* also
+// call `step()` - it only reads. `GamepadInputSource` only re-dispatches an
+// action when its *own* polled value changes since the previous poll (see
+// its class doc comment), so an extra, unaccounted-for poll (as an
+// always-steps `captureState` would add here) changes which frame the
+// "stuck at zero" scenario below lands on. Every `step()` in this spec is
+// therefore explicit, and `readState` is always called either with no step
+// in between (to inspect the result of the last explicit step) or paired
+// 1:1 with exactly one `step()`.
+const readState = (page: Page) =>
+  page.evaluate(
+    ({ blue, yellow, cyan }) => {
+      const scene = window.__forgeTestHooks as unknown as Hooks;
+
+      return {
+        stickPosition: scene.stickPosition,
+        brokenStickPosition: scene.brokenStickPosition,
+        menuStickPosition: scene.menuStickPosition,
+        stickBounds: scene.measureBounds(blue),
+        brokenBounds: scene.measureBounds(yellow),
+        menuStickBounds: scene.measureBounds(cyan),
+      };
+    },
+    {
+      blue: inputSceneColors.blue,
+      yellow: inputSceneColors.yellow,
+      cyan: inputSceneColors.cyan,
+    },
+  );
+
+const step = (page: Page) =>
+  page.evaluate(() => (window.__forgeTestHooks as unknown as Hooks).step());
+
+const stepAndReadState = async (page: Page) => {
+  await step(page);
+
+  return readState(page);
+};
+
+const setStickX = (page: Page, value: number) =>
+  page.evaluate(
+    (v) => (window.__forgeTestHooks as unknown as Hooks).setStickX(v),
+    value,
+  );
+
+// Spreads a change over several real-time-spaced frames so it's actually
+// watchable in the recorded video (playwright.config.ts's `video: 'on'`),
+// following camera-pan-zoom.spec.ts's `animateFrames` pattern.
+const frameSpacingMilliseconds = 60;
+
+const animateFrames = async (
+  page: Page,
+  frameCount: number,
+  onFrame?: () => Promise<void>,
+): Promise<void> => {
+  for (let frame = 0; frame < frameCount; frame++) {
+    // eslint-disable-next-line no-await-in-loop
+    await onFrame?.();
+    // eslint-disable-next-line no-await-in-loop
+    await step(page);
+    // eslint-disable-next-line no-await-in-loop, sonarjs/no-fixed-wait-in-tests
+    await page.waitForTimeout(frameSpacingMilliseconds);
+  }
+};
+
+test.describe('gamepad input', () => {
+  test.beforeEach(async ({ page }) => {
+    await test.step('load the gamepad-input scene', async () => {
+      let pageError: Error | undefined;
+
+      page.once('pageerror', (error) => {
+        pageError = error;
+      });
+
+      await page.goto('/?scene=gamepad-input');
+
+      try {
+        await page.waitForFunction(() => Boolean(window.__forgeTestHooks));
+      } catch (timeoutError) {
+        throw pageError ?? timeoutError;
+      }
+    });
+  });
+
+  test('Axis1dAction with noReset tracks a held stick deflection and ignores deadzone drift', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      stepAndReadState(page));
+
+    await test.step('deflect the stick within the deadzone', () =>
+      setStickX(page, 0.05));
+
+    const withinDeadzone =
+      await test.step('capture the state with a within-deadzone deflection', () =>
+        stepAndReadState(page));
+
+    // Stick values within +-0.15 of 0 are treated as 0.
+    expect(withinDeadzone.stickPosition.x).toBe(before.stickPosition.x);
+
+    await test.step('deflect the stick well past the deadzone', () =>
+      setStickX(page, 0.8));
+
+    const deflected = await test.step('capture the state while deflected', () =>
+      stepAndReadState(page));
+
+    expect(deflected.stickPosition.x).toBeGreaterThan(
+      withinDeadzone.stickPosition.x,
+    );
+
+    await test.step('assert the stick square visibly moved right on screen', () => {
+      expect(before.stickBounds).not.toBeNull();
+      expect(deflected.stickBounds).not.toBeNull();
+
+      const centerBefore =
+        (before.stickBounds!.left + before.stickBounds!.right) / 2;
+      const centerDeflected =
+        (deflected.stickBounds!.left + deflected.stickBounds!.right) / 2;
+
+      expect(centerDeflected).toBeGreaterThan(centerBefore);
+    });
+
+    await test.step('hold the same deflection over several more frames without it drifting further', () =>
+      animateFrames(page, 5));
+
+    const stillDeflected =
+      await test.step('capture the state after holding the deflection', () =>
+        readState(page));
+
+    // The action's own value should be stable while the stick reading is
+    // unchanged - this is about the *action*, not the polling-skip
+    // optimization under test elsewhere in this file.
+    expect(stillDeflected.stickPosition.x).toBe(deflected.stickPosition.x);
+
+    await test.step('release the stick back to center', () =>
+      setStickX(page, 0));
+
+    const released =
+      await test.step('capture the state after releasing the stick', () =>
+        stepAndReadState(page));
+
+    expect(released.stickPosition.x).toBe(before.stickPosition.x);
+  });
+
+  test('Axis1dAction with the default zero reset reads correctly for one frame, then gets stuck at zero', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      stepAndReadState(page));
+
+    await test.step('deflect the stick', () => setStickX(page, 0.8));
+
+    const afterFirstFrame =
+      await test.step('capture the state right after the first polled frame with the new deflection', () =>
+        stepAndReadState(page));
+
+    expect(afterFirstFrame.brokenStickPosition.x).toBeGreaterThan(
+      before.brokenStickPosition.x,
+    );
+
+    const stillDeflected =
+      await test.step('advance one more frame without changing the stick reading', () =>
+        stepAndReadState(page));
+
+    // This is the documented pitfall (gamepad.md's "Gotchas"): the default
+    // `actionResetTypes.zero` resets the value to 0 every frame, but the
+    // source only re-dispatches when its own reading of the stick changes.
+    // Since the stick's raw reading hasn't changed since the previous poll,
+    // the source never notices the value was reset out from under it, so
+    // the action stays stuck at 0 - snapped back to its base position -
+    // even though the stick is still fully deflected.
+    expect(stillDeflected.brokenStickPosition.x).toBe(
+      before.brokenStickPosition.x,
+    );
+
+    await test.step('keep holding the same deflection over several more frames', () =>
+      animateFrames(page, 5));
+
+    const remainsStuck =
+      await test.step('capture the state after holding the deflection further', () =>
+        readState(page));
+
+    await test.step('assert the broken square visibly stayed snapped to its base position', () => {
+      expect(before.brokenBounds).not.toBeNull();
+      expect(remainsStuck.brokenBounds).not.toBeNull();
+
+      const centerBefore =
+        (before.brokenBounds!.left + before.brokenBounds!.right) / 2;
+      const centerRemainsStuck =
+        (remainsStuck.brokenBounds!.left + remainsStuck.brokenBounds!.right) /
+        2;
+
+      expect(centerRemainsStuck).toBeCloseTo(centerBefore, -1);
+    });
+  });
+
+  test('input groups gate which Axis1dAction a shared stick axis dispatches to', async ({
+    page,
+  }) => {
+    const initial = await test.step('capture the starting state', () =>
+      stepAndReadState(page));
+
+    await test.step('deflect the stick right while the "game" group is active', () =>
+      setStickX(page, 0.6));
+
+    const afterGameDeflection =
+      await test.step('capture the state after the "game"-group deflection', () =>
+        stepAndReadState(page));
+
+    expect(afterGameDeflection.stickPosition.x).toBeGreaterThan(
+      initial.stickPosition.x,
+    );
+    // The "menu"-group action must not have received the deflection at all.
+    expect(afterGameDeflection.menuStickPosition.x).toBe(
+      initial.menuStickPosition.x,
+    );
+
+    await test.step('switch the active group to "menu"', () =>
+      page.evaluate(() =>
+        (window.__forgeTestHooks as unknown as Hooks).setActiveGroup('menu'),
+      ));
+
+    await test.step('deflect the stick to a new value while the "menu" group is active', () =>
+      setStickX(page, -0.6));
+
+    const afterMenuDeflection =
+      await test.step('capture the state after the "menu"-group deflection', () =>
+        stepAndReadState(page));
+
+    // The "game" action must not have picked up the new deflection - it's
+    // gated, not just quiet because nothing changed.
+    expect(afterMenuDeflection.stickPosition.x).toBe(
+      afterGameDeflection.stickPosition.x,
+    );
+    expect(afterMenuDeflection.menuStickPosition.x).toBeLessThan(
+      afterGameDeflection.menuStickPosition.x,
+    );
+
+    await test.step('assert the "menu" square visibly moved left on screen', () => {
+      expect(afterGameDeflection.menuStickBounds).not.toBeNull();
+      expect(afterMenuDeflection.menuStickBounds).not.toBeNull();
+
+      const centerAfterGame =
+        (afterGameDeflection.menuStickBounds!.left +
+          afterGameDeflection.menuStickBounds!.right) /
+        2;
+      const centerAfterMenu =
+        (afterMenuDeflection.menuStickBounds!.left +
+          afterMenuDeflection.menuStickBounds!.right) /
+        2;
+
+      expect(centerAfterMenu).toBeLessThan(centerAfterGame);
+    });
+
+    await test.step('switch back to "game" and deflect to a third value', () =>
+      page.evaluate(() =>
+        (window.__forgeTestHooks as unknown as Hooks).setActiveGroup('game'),
+      ));
+    await test.step('deflect the stick to a third value', () =>
+      setStickX(page, 0.9));
+
+    const afterSwitchingBack =
+      await test.step('capture the state after switching back to "game"', () =>
+        stepAndReadState(page));
+
+    expect(afterSwitchingBack.stickPosition.x).toBeGreaterThan(
+      afterGameDeflection.stickPosition.x,
+    );
+    expect(afterSwitchingBack.menuStickPosition.x).toBe(
+      afterMenuDeflection.menuStickPosition.x,
+    );
+  });
+});

--- a/e2e/specs/keyboard-input.spec.ts
+++ b/e2e/specs/keyboard-input.spec.ts
@@ -1,0 +1,354 @@
+import { expect, test } from '@playwright/test';
+import { inputSceneColors } from '../fixtures/scenes/input-scene-colors.js';
+import type { KeyboardInputSceneHandle } from '../fixtures/scenes/keyboard-input.js';
+
+// `window.__forgeTestHooks` is declared globally (as the base `SceneHandle`)
+// by `harness.ts`. Each `page.evaluate` callback below narrows it to this
+// spec's own scene handle type inline - see camera-pan-zoom.spec.ts's `Hooks`
+// comment for why.
+type Hooks = KeyboardInputSceneHandle;
+type Page = import('@playwright/test').Page;
+
+const captureState = (page: Page) =>
+  page.evaluate(
+    ({ blue, yellow, red, green, magenta, orange }) => {
+      const scene = window.__forgeTestHooks as unknown as Hooks;
+
+      scene.step();
+
+      return {
+        moverPosition: scene.moverPosition,
+        impulsePosition: scene.impulsePosition,
+        gameTriggerCount: scene.gameTriggerCount,
+        menuTriggerCount: scene.menuTriggerCount,
+        isCrouching: scene.isCrouching,
+        moverBounds: scene.measureBounds(blue),
+        impulseBounds: scene.measureBounds(yellow),
+        redMarkerBounds: scene.measureBounds(red),
+        greenMarkerBounds: scene.measureBounds(green),
+        magentaMarkerBounds: scene.measureBounds(magenta),
+        holdBounds: scene.measureBounds(orange),
+      };
+    },
+    {
+      blue: inputSceneColors.blue,
+      yellow: inputSceneColors.yellow,
+      red: inputSceneColors.red,
+      green: inputSceneColors.green,
+      magenta: inputSceneColors.magenta,
+      orange: inputSceneColors.orange,
+    },
+  );
+
+const step = (page: Page) =>
+  page.evaluate(() => (window.__forgeTestHooks as unknown as Hooks).step());
+
+// Spreads a change over several real-time-spaced frames so it's actually
+// watchable in the recorded video (playwright.config.ts's `video: 'on'`),
+// following camera-pan-zoom.spec.ts's `animateFrames` pattern.
+const frameSpacingMilliseconds = 60;
+
+const animateFrames = async (
+  page: Page,
+  frameCount: number,
+  onFrame?: () => Promise<void>,
+): Promise<void> => {
+  for (let frame = 0; frame < frameCount; frame++) {
+    // eslint-disable-next-line no-await-in-loop
+    await onFrame?.();
+    // eslint-disable-next-line no-await-in-loop
+    await step(page);
+    // eslint-disable-next-line no-await-in-loop, sonarjs/no-fixed-wait-in-tests
+    await page.waitForTimeout(frameSpacingMilliseconds);
+  }
+};
+
+test.describe('keyboard input', () => {
+  test.beforeEach(async ({ page }) => {
+    await test.step('load the keyboard-input scene', async () => {
+      let pageError: Error | undefined;
+
+      page.once('pageerror', (error) => {
+        pageError = error;
+      });
+
+      await page.goto('/?scene=keyboard-input');
+
+      try {
+        await page.waitForFunction(() => Boolean(window.__forgeTestHooks));
+      } catch (timeoutError) {
+        throw pageError ?? timeoutError;
+      }
+    });
+  });
+
+  test('Axis2dAction with noReset moves continuously while WASD is held, and stops on release', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    await test.step('hold D over several frames', async () => {
+      await page.keyboard.down('KeyD');
+      await animateFrames(page, 10);
+    });
+
+    const whileHeld = await test.step('capture the state while held', () =>
+      captureState(page));
+
+    expect(whileHeld.moverPosition.x).toBeGreaterThan(before.moverPosition.x);
+
+    await test.step('assert the mover square visibly moved right on screen', () => {
+      expect(before.moverBounds).not.toBeNull();
+      expect(whileHeld.moverBounds).not.toBeNull();
+
+      const centerBefore =
+        (before.moverBounds!.left + before.moverBounds!.right) / 2;
+      const centerWhileHeld =
+        (whileHeld.moverBounds!.left + whileHeld.moverBounds!.right) / 2;
+
+      expect(centerWhileHeld).toBeGreaterThan(centerBefore);
+    });
+
+    await test.step('release D and advance one more frame', async () => {
+      await page.keyboard.up('KeyD');
+      await animateFrames(page, 1);
+    });
+
+    const afterRelease =
+      await test.step('capture the state after release', () =>
+        captureState(page));
+
+    const oneMoreStepLater =
+      await test.step('capture the state one more frame later', () =>
+        captureState(page));
+
+    // noReset means the value is left at whatever it was last set to (0,
+    // dispatched by the keyup handler), so movement should have fully
+    // stopped instead of continuing or reverting.
+    expect(oneMoreStepLater.moverPosition.x).toBe(afterRelease.moverPosition.x);
+  });
+
+  test('Axis1dAction with the default zero reset only moves for one frame per key event, even while held', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    await test.step('press ArrowRight down and advance one frame', async () => {
+      await page.keyboard.down('ArrowRight');
+      await animateFrames(page, 1);
+    });
+
+    const afterFirstFrame =
+      await test.step('capture the state right after the key-down frame', () =>
+        captureState(page));
+
+    expect(afterFirstFrame.impulsePosition.x).toBeGreaterThan(
+      before.impulsePosition.x,
+    );
+
+    await test.step('assert the impulse square visibly jumped right on screen', () => {
+      expect(before.impulseBounds).not.toBeNull();
+      expect(afterFirstFrame.impulseBounds).not.toBeNull();
+
+      const centerBefore =
+        (before.impulseBounds!.left + before.impulseBounds!.right) / 2;
+      const centerAfter =
+        (afterFirstFrame.impulseBounds!.left +
+          afterFirstFrame.impulseBounds!.right) /
+        2;
+
+      expect(centerAfter).toBeGreaterThan(centerBefore);
+    });
+
+    await test.step('keep holding ArrowRight over several more frames without it moving further', () =>
+      animateFrames(page, 8));
+
+    const stillHeld =
+      await test.step('capture the state after holding for several more frames', () =>
+        captureState(page));
+
+    // The default `actionResetTypes.zero` zeroes the axis value every frame
+    // regardless of key state (see actions.md's "Reset behavior" caution),
+    // so a held-but-not-newly-pressed key produces no further movement.
+    expect(stillHeld.impulsePosition.x).toBe(afterFirstFrame.impulsePosition.x);
+
+    await test.step('release ArrowRight and advance one frame', async () => {
+      await page.keyboard.up('ArrowRight');
+      await animateFrames(page, 1);
+    });
+
+    const afterRelease =
+      await test.step('capture the state after release', () =>
+        captureState(page));
+
+    // The documented "twitch": because the value had already been reset to
+    // 0 while held, the keyup handler's delta computation starts from 0
+    // instead of the original +1, producing a compensating -1 impulse on
+    // release. Net effect over the whole press-hold-release cycle: the
+    // square ends up back where it started.
+    expect(afterRelease.impulsePosition.x).toBeCloseTo(
+      before.impulsePosition.x,
+      5,
+    );
+  });
+
+  test('TriggerAction fires once per key press, not per frame held', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    expect(before.gameTriggerCount).toBe(0);
+
+    await test.step('press and hold Space over several frames', async () => {
+      await page.keyboard.down('Space');
+      await animateFrames(page, 6);
+    });
+
+    const whileHeld = await test.step('capture the state while held', () =>
+      captureState(page));
+
+    // KeyboardInputSource filters out the browser's auto-repeat keydown
+    // events, so holding the key must not re-trigger every frame.
+    expect(whileHeld.gameTriggerCount).toBe(1);
+
+    await test.step('assert the marker square turned green on screen', () => {
+      expect(whileHeld.greenMarkerBounds).not.toBeNull();
+      expect(whileHeld.redMarkerBounds).toBeNull();
+    });
+
+    await test.step('release and press Space again', async () => {
+      await page.keyboard.up('Space');
+      await animateFrames(page, 2);
+      await page.keyboard.down('Space');
+      await animateFrames(page, 2);
+      await page.keyboard.up('Space');
+      await animateFrames(page, 1);
+    });
+
+    const afterSecondPress =
+      await test.step('capture the state after the second press', () =>
+        captureState(page));
+
+    expect(afterSecondPress.gameTriggerCount).toBe(2);
+
+    await test.step('assert the marker square toggled back to red on screen', () => {
+      expect(afterSecondPress.redMarkerBounds).not.toBeNull();
+      expect(afterSecondPress.greenMarkerBounds).toBeNull();
+    });
+  });
+
+  test('HoldAction grows the square while held, and shrinks it back on release', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    expect(before.isCrouching).toBe(false);
+    expect(before.holdBounds).not.toBeNull();
+
+    const widthBefore = before.holdBounds!.right - before.holdBounds!.left;
+
+    await test.step('press and hold KeyC', async () => {
+      await page.keyboard.down('KeyC');
+      await animateFrames(page, 4);
+    });
+
+    const whileHeld = await test.step('capture the state while held', () =>
+      captureState(page));
+
+    expect(whileHeld.isCrouching).toBe(true);
+
+    const widthWhileHeld =
+      whileHeld.holdBounds!.right - whileHeld.holdBounds!.left;
+
+    expect(widthWhileHeld).toBeGreaterThan(widthBefore);
+
+    await test.step('release KeyC', async () => {
+      await page.keyboard.up('KeyC');
+      await animateFrames(page, 1);
+    });
+
+    const afterRelease =
+      await test.step('capture the state after release', () =>
+        captureState(page));
+
+    expect(afterRelease.isCrouching).toBe(false);
+
+    const widthAfterRelease =
+      afterRelease.holdBounds!.right - afterRelease.holdBounds!.left;
+
+    // Generous tolerance for antialiased edge pixels, not an exact byte
+    // match - see input-scene-helpers.ts's `colorMatchTolerance`.
+    expect(Math.abs(widthAfterRelease - widthBefore)).toBeLessThan(4);
+  });
+
+  test('input groups gate which TriggerAction the same key dispatches to', async ({
+    page,
+  }) => {
+    const initial = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    expect(initial.gameTriggerCount).toBe(0);
+    expect(initial.menuTriggerCount).toBe(0);
+
+    await test.step('press Space while the "game" group is active', async () => {
+      await page.keyboard.down('Space');
+      await animateFrames(page, 2);
+      await page.keyboard.up('Space');
+      await animateFrames(page, 1);
+    });
+
+    const afterGamePress =
+      await test.step('capture the state after the "game"-group press', () =>
+        captureState(page));
+
+    expect(afterGamePress.gameTriggerCount).toBe(1);
+    expect(afterGamePress.menuTriggerCount).toBe(0);
+    expect(afterGamePress.magentaMarkerBounds).toBeNull();
+
+    await test.step('switch the active group to "menu"', () =>
+      page.evaluate(() =>
+        (window.__forgeTestHooks as unknown as Hooks).setActiveGroup('menu'),
+      ));
+
+    await test.step('press Space while the "menu" group is active', async () => {
+      await page.keyboard.down('Space');
+      await animateFrames(page, 2);
+      await page.keyboard.up('Space');
+      await animateFrames(page, 1);
+    });
+
+    const afterMenuPress =
+      await test.step('capture the state after the "menu"-group press', () =>
+        captureState(page));
+
+    // The "game" trigger must not have fired again - only its group's
+    // dispatch was gated, proving the gate is per-binding, not global.
+    expect(afterMenuPress.gameTriggerCount).toBe(1);
+    expect(afterMenuPress.menuTriggerCount).toBe(1);
+
+    await test.step('assert the marker square turned magenta on screen', () => {
+      expect(afterMenuPress.magentaMarkerBounds).not.toBeNull();
+    });
+
+    await test.step('switch back to "game" and press Space once more', async () => {
+      await page.evaluate(() =>
+        (window.__forgeTestHooks as unknown as Hooks).setActiveGroup('game'),
+      );
+      await page.keyboard.down('Space');
+      await animateFrames(page, 2);
+      await page.keyboard.up('Space');
+      await animateFrames(page, 1);
+    });
+
+    const afterSwitchingBack =
+      await test.step('capture the state after switching back to "game"', () =>
+        captureState(page));
+
+    expect(afterSwitchingBack.gameTriggerCount).toBe(2);
+    expect(afterSwitchingBack.menuTriggerCount).toBe(1);
+  });
+});

--- a/e2e/specs/mouse-input.spec.ts
+++ b/e2e/specs/mouse-input.spec.ts
@@ -1,0 +1,346 @@
+import { expect, test } from '@playwright/test';
+import { inputSceneColors } from '../fixtures/scenes/input-scene-colors.js';
+import type { MouseInputSceneHandle } from '../fixtures/scenes/mouse-input.js';
+
+// `window.__forgeTestHooks` is declared globally (as the base `SceneHandle`)
+// by `harness.ts`. Each `page.evaluate` callback below narrows it to this
+// spec's own scene handle type inline - see camera-pan-zoom.spec.ts's `Hooks`
+// comment for why.
+type Hooks = MouseInputSceneHandle;
+type Page = import('@playwright/test').Page;
+
+// The fixture's #app container - and therefore the canvas - is 800x600 and
+// sits at the page's top-left corner (see e2e/fixtures/index.html), so page
+// coordinates map 1:1 onto canvas coordinates.
+const canvasWidth = 800;
+const canvasHeight = 600;
+const canvasCenterX = canvasWidth / 2;
+const canvasCenterY = canvasHeight / 2;
+
+const captureState = (page: Page) =>
+  page.evaluate(
+    ({ blue, yellow, red, green, magenta, orange }) => {
+      const scene = window.__forgeTestHooks as unknown as Hooks;
+
+      scene.step();
+
+      return {
+        pointerPosition: scene.pointerPosition,
+        scrollPosition: scene.scrollPosition,
+        gameTriggerCount: scene.gameTriggerCount,
+        menuTriggerCount: scene.menuTriggerCount,
+        isAiming: scene.isAiming,
+        pointerBounds: scene.measureBounds(blue),
+        scrollBounds: scene.measureBounds(yellow),
+        redMarkerBounds: scene.measureBounds(red),
+        greenMarkerBounds: scene.measureBounds(green),
+        magentaMarkerBounds: scene.measureBounds(magenta),
+        holdBounds: scene.measureBounds(orange),
+      };
+    },
+    {
+      blue: inputSceneColors.blue,
+      yellow: inputSceneColors.yellow,
+      red: inputSceneColors.red,
+      green: inputSceneColors.green,
+      magenta: inputSceneColors.magenta,
+      orange: inputSceneColors.orange,
+    },
+  );
+
+const step = (page: Page) =>
+  page.evaluate(() => (window.__forgeTestHooks as unknown as Hooks).step());
+
+// Spreads a change over several real-time-spaced frames so it's actually
+// watchable in the recorded video (playwright.config.ts's `video: 'on'`),
+// following camera-pan-zoom.spec.ts's `animateFrames` pattern.
+const frameSpacingMilliseconds = 60;
+
+const animateFrames = async (
+  page: Page,
+  frameCount: number,
+  onFrame?: () => Promise<void>,
+): Promise<void> => {
+  for (let frame = 0; frame < frameCount; frame++) {
+    // eslint-disable-next-line no-await-in-loop
+    await onFrame?.();
+    // eslint-disable-next-line no-await-in-loop
+    await step(page);
+    // eslint-disable-next-line no-await-in-loop, sonarjs/no-fixed-wait-in-tests
+    await page.waitForTimeout(frameSpacingMilliseconds);
+  }
+};
+
+test.describe('mouse input', () => {
+  test.beforeEach(async ({ page }) => {
+    await test.step('load the mouse-input scene', async () => {
+      let pageError: Error | undefined;
+
+      page.once('pageerror', (error) => {
+        pageError = error;
+      });
+
+      await page.goto('/?scene=mouse-input');
+
+      try {
+        await page.waitForFunction(() => Boolean(window.__forgeTestHooks));
+      } catch (timeoutError) {
+        throw pageError ?? timeoutError;
+      }
+
+      // Establishes the cursor's starting ratio at dead center before any
+      // test-specific movement, so every test starts from the same known
+      // `pointerAction.value` of (0, 0).
+      await page.mouse.move(canvasCenterX, canvasCenterY);
+      await step(page);
+    });
+  });
+
+  test('Axis2dAction with noReset tracks the cursor and holds position between mousemove events', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    await test.step('move the mouse toward the right edge of the canvas', async () => {
+      await page.mouse.move(canvasWidth - 50, canvasCenterY);
+      await animateFrames(page, 3);
+    });
+
+    const afterMove = await test.step('capture the state after moving', () =>
+      captureState(page));
+
+    expect(afterMove.pointerPosition.x).toBeGreaterThan(
+      before.pointerPosition.x,
+    );
+
+    await test.step('assert the pointer square visibly moved right on screen', () => {
+      expect(before.pointerBounds).not.toBeNull();
+      expect(afterMove.pointerBounds).not.toBeNull();
+
+      const centerBefore =
+        (before.pointerBounds!.left + before.pointerBounds!.right) / 2;
+      const centerAfterMove =
+        (afterMove.pointerBounds!.left + afterMove.pointerBounds!.right) / 2;
+
+      expect(centerAfterMove).toBeGreaterThan(centerBefore);
+    });
+
+    await test.step('advance several more frames without moving the mouse further', () =>
+      animateFrames(page, 5));
+
+    const stillStill =
+      await test.step('capture the state after holding the cursor still', () =>
+        captureState(page));
+
+    // noReset means the last-dispatched ratio persists, so the square keeps
+    // tracking the same position instead of drifting or snapping back.
+    expect(stillStill.pointerPosition.x).toBe(afterMove.pointerPosition.x);
+  });
+
+  test('Axis1dAction with the default zero reset only moves for one frame per wheel event', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    await test.step('scroll the wheel once and advance one frame', async () => {
+      await page.locator('canvas').dispatchEvent('wheel', { deltaY: -100 });
+      await animateFrames(page, 1);
+    });
+
+    const afterScroll =
+      await test.step('capture the state right after the scroll frame', () =>
+        captureState(page));
+
+    expect(afterScroll.scrollPosition.x).not.toBe(before.scrollPosition.x);
+
+    await test.step('assert the scroll square visibly moved on screen', () => {
+      expect(before.scrollBounds).not.toBeNull();
+      expect(afterScroll.scrollBounds).not.toBeNull();
+
+      const centerBefore =
+        (before.scrollBounds!.left + before.scrollBounds!.right) / 2;
+      const centerAfterScroll =
+        (afterScroll.scrollBounds!.left + afterScroll.scrollBounds!.right) / 2;
+
+      expect(centerAfterScroll).not.toBe(centerBefore);
+    });
+
+    await test.step('advance several more frames without scrolling again', () =>
+      animateFrames(page, 6));
+
+    const stillAfter =
+      await test.step('capture the state after several more frames', () =>
+        captureState(page));
+
+    // The default `actionResetTypes.zero` zeroes the axis value every frame
+    // - correct here, since a wheel event has no "up" counterpart to reverse
+    // a lingering value the way a key or button release would.
+    expect(stillAfter.scrollPosition.x).toBe(afterScroll.scrollPosition.x);
+  });
+
+  test('TriggerAction fires once per click, not per frame held', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    expect(before.gameTriggerCount).toBe(0);
+
+    await test.step('press and hold the left button over several frames', async () => {
+      await page.mouse.move(canvasCenterX, canvasCenterY);
+      await page.mouse.down({ button: 'left' });
+      await animateFrames(page, 6);
+    });
+
+    const whileHeld = await test.step('capture the state while held', () =>
+      captureState(page));
+
+    expect(whileHeld.gameTriggerCount).toBe(1);
+
+    await test.step('assert the marker square turned green on screen', () => {
+      expect(whileHeld.greenMarkerBounds).not.toBeNull();
+      expect(whileHeld.redMarkerBounds).toBeNull();
+    });
+
+    await test.step('release and click again', async () => {
+      await page.mouse.up({ button: 'left' });
+      await animateFrames(page, 2);
+      await page.mouse.down({ button: 'left' });
+      await animateFrames(page, 2);
+      await page.mouse.up({ button: 'left' });
+      await animateFrames(page, 1);
+    });
+
+    const afterSecondClick =
+      await test.step('capture the state after the second click', () =>
+        captureState(page));
+
+    expect(afterSecondClick.gameTriggerCount).toBe(2);
+
+    await test.step('assert the marker square toggled back to red on screen', () => {
+      expect(afterSecondClick.redMarkerBounds).not.toBeNull();
+      expect(afterSecondClick.greenMarkerBounds).toBeNull();
+    });
+  });
+
+  test('HoldAction grows the square while the right button is held, and shrinks it back on release', async ({
+    page,
+  }) => {
+    const before = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    expect(before.isAiming).toBe(false);
+    expect(before.holdBounds).not.toBeNull();
+
+    const widthBefore = before.holdBounds!.right - before.holdBounds!.left;
+
+    await test.step('press and hold the right button', async () => {
+      await page.mouse.move(canvasCenterX, canvasCenterY);
+      await page.mouse.down({ button: 'right' });
+      await animateFrames(page, 4);
+    });
+
+    const whileHeld = await test.step('capture the state while held', () =>
+      captureState(page));
+
+    expect(whileHeld.isAiming).toBe(true);
+
+    const widthWhileHeld =
+      whileHeld.holdBounds!.right - whileHeld.holdBounds!.left;
+
+    expect(widthWhileHeld).toBeGreaterThan(widthBefore);
+
+    await test.step('release the right button', async () => {
+      await page.mouse.up({ button: 'right' });
+      await animateFrames(page, 1);
+    });
+
+    const afterRelease =
+      await test.step('capture the state after release', () =>
+        captureState(page));
+
+    expect(afterRelease.isAiming).toBe(false);
+
+    const widthAfterRelease =
+      afterRelease.holdBounds!.right - afterRelease.holdBounds!.left;
+
+    // Generous tolerance for antialiased edge pixels, not an exact byte
+    // match - see input-scene-helpers.ts's `colorMatchTolerance`.
+    expect(Math.abs(widthAfterRelease - widthBefore)).toBeLessThan(4);
+  });
+
+  test('input groups gate which TriggerAction the same button dispatches to, including for MouseInputSource', async ({
+    page,
+  }) => {
+    const initial = await test.step('capture the starting state', () =>
+      captureState(page));
+
+    expect(initial.gameTriggerCount).toBe(0);
+    expect(initial.menuTriggerCount).toBe(0);
+
+    await test.step('click the left button while the "game" group is active', async () => {
+      await page.mouse.move(canvasCenterX, canvasCenterY);
+      await page.mouse.down({ button: 'left' });
+      await animateFrames(page, 2);
+      await page.mouse.up({ button: 'left' });
+      await animateFrames(page, 1);
+    });
+
+    const afterGameClick =
+      await test.step('capture the state after the "game"-group click', () =>
+        captureState(page));
+
+    // This is the regression this test guards: MouseInputSource used to
+    // call `TriggerAction.trigger()` directly, bypassing InputManager's
+    // active-group gating entirely (unlike KeyboardInputSource). If that
+    // regressed, `menuTriggerCount` below would be 1 even though the
+    // "menu" group was never active.
+    expect(afterGameClick.gameTriggerCount).toBe(1);
+    expect(afterGameClick.menuTriggerCount).toBe(0);
+    expect(afterGameClick.magentaMarkerBounds).toBeNull();
+
+    await test.step('switch the active group to "menu"', () =>
+      page.evaluate(() =>
+        (window.__forgeTestHooks as unknown as Hooks).setActiveGroup('menu'),
+      ));
+
+    await test.step('click the left button while the "menu" group is active', async () => {
+      await page.mouse.down({ button: 'left' });
+      await animateFrames(page, 2);
+      await page.mouse.up({ button: 'left' });
+      await animateFrames(page, 1);
+    });
+
+    const afterMenuClick =
+      await test.step('capture the state after the "menu"-group click', () =>
+        captureState(page));
+
+    // The "game" trigger must not have fired again - only its group's
+    // dispatch was gated, proving the gate is per-binding, not global.
+    expect(afterMenuClick.gameTriggerCount).toBe(1);
+    expect(afterMenuClick.menuTriggerCount).toBe(1);
+
+    await test.step('assert the marker square turned magenta on screen', () => {
+      expect(afterMenuClick.magentaMarkerBounds).not.toBeNull();
+    });
+
+    await test.step('switch back to "game" and click once more', async () => {
+      await page.evaluate(() =>
+        (window.__forgeTestHooks as unknown as Hooks).setActiveGroup('game'),
+      );
+      await page.mouse.down({ button: 'left' });
+      await animateFrames(page, 2);
+      await page.mouse.up({ button: 'left' });
+      await animateFrames(page, 1);
+    });
+
+    const afterSwitchingBack =
+      await test.step('capture the state after switching back to "game"', () =>
+        captureState(page));
+
+    expect(afterSwitchingBack.gameTriggerCount).toBe(2);
+    expect(afterSwitchingBack.menuTriggerCount).toBe(1);
+  });
+});

--- a/src/input/mouse/input-sources/mouse-input-source.test.ts
+++ b/src/input/mouse/input-sources/mouse-input-source.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MouseInputSource } from './mouse-input-source';
+import { buttonMoments, mouseButtons } from '../../constants';
+import { InputManager } from '../../input-manager';
+import { HoldAction, TriggerAction } from '../../actions';
+import { MouseHoldBinding, MouseTriggerBinding } from '../bindings';
+
+describe('MouseInputSource', () => {
+  const group = 'default';
+
+  let container: HTMLDivElement;
+  let inputManager: InputManager;
+  let source: MouseInputSource;
+  let clickDownAction: TriggerAction;
+  let clickUpAction: TriggerAction;
+  let holdAction: HoldAction;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    inputManager = new InputManager();
+    inputManager.setActiveGroup(group);
+    source = new MouseInputSource(inputManager, container);
+
+    clickDownAction = new TriggerAction('clickDownAction', group);
+    clickUpAction = new TriggerAction('clickUpAction', group);
+    holdAction = new HoldAction('holdAction', group);
+
+    inputManager.addResettable(clickDownAction);
+    inputManager.addResettable(clickUpAction);
+
+    source.triggerBindings.add(
+      new MouseTriggerBinding(
+        clickDownAction,
+        mouseButtons.left,
+        buttonMoments.down,
+      ),
+    );
+
+    source.triggerBindings.add(
+      new MouseTriggerBinding(
+        clickUpAction,
+        mouseButtons.left,
+        buttonMoments.up,
+      ),
+    );
+
+    source.holdBindings.add(
+      new MouseHoldBinding(holdAction, mouseButtons.right),
+    );
+  });
+
+  it('dispatches mouse down trigger actions', () => {
+    expect(clickDownAction.isTriggered).toBe(false);
+
+    container.dispatchEvent(
+      new MouseEvent('mousedown', { button: mouseButtons.left }),
+    );
+    expect(clickDownAction.isTriggered).toBe(true);
+
+    inputManager.reset();
+    expect(clickDownAction.isTriggered).toBe(false);
+  });
+
+  it('dispatches mouse up trigger actions', () => {
+    expect(clickUpAction.isTriggered).toBe(false);
+
+    container.dispatchEvent(
+      new MouseEvent('mouseup', { button: mouseButtons.left }),
+    );
+    expect(clickUpAction.isTriggered).toBe(true);
+
+    inputManager.reset();
+    expect(clickUpAction.isTriggered).toBe(false);
+  });
+
+  it('does not dispatch mouse down triggers for a group other than the active group', () => {
+    const menuAction = new TriggerAction('menuAction', 'menu');
+
+    inputManager.addResettable(menuAction);
+    source.triggerBindings.add(
+      new MouseTriggerBinding(
+        menuAction,
+        mouseButtons.left,
+        buttonMoments.down,
+      ),
+    );
+
+    container.dispatchEvent(
+      new MouseEvent('mousedown', { button: mouseButtons.left }),
+    );
+
+    expect(clickDownAction.isTriggered).toBe(true);
+    expect(menuAction.isTriggered).toBe(false);
+  });
+
+  it('dispatches mouse hold actions', () => {
+    expect(holdAction.isHeld).toBe(false);
+
+    container.dispatchEvent(
+      new MouseEvent('mousedown', { button: mouseButtons.right }),
+    );
+    expect(holdAction.isHeld).toBe(true);
+
+    container.dispatchEvent(
+      new MouseEvent('mouseup', { button: mouseButtons.right }),
+    );
+    expect(holdAction.isHeld).toBe(false);
+  });
+
+  it('does not dispatch mouse hold start actions for a group other than the active group', () => {
+    const menuHoldAction = new HoldAction('menuHoldAction', 'menu');
+
+    source.holdBindings.add(
+      new MouseHoldBinding(menuHoldAction, mouseButtons.right),
+    );
+
+    container.dispatchEvent(
+      new MouseEvent('mousedown', { button: mouseButtons.right }),
+    );
+
+    expect(holdAction.isHeld).toBe(true);
+    expect(menuHoldAction.isHeld).toBe(false);
+  });
+});

--- a/src/input/mouse/input-sources/mouse-input-source.ts
+++ b/src/input/mouse/input-sources/mouse-input-source.ts
@@ -99,7 +99,7 @@ export class MouseInputSource
         binding.mouseButton === button &&
         binding.moment === buttonMoments.down
       ) {
-        binding.action.trigger();
+        this._inputManager.dispatchTriggerAction(binding);
       }
     }
 
@@ -122,7 +122,7 @@ export class MouseInputSource
         binding.mouseButton === button &&
         binding.moment === buttonMoments.up
       ) {
-        binding.action.trigger();
+        this._inputManager.dispatchTriggerAction(binding);
       }
     }
 


### PR DESCRIPTION
## Summary

Adds a real-browser Playwright suite covering the input system end-to-end, per `AGENTS.md`'s "Integration & E2E Testing" and the `write-e2e-test` skill: three new scenes/specs (`keyboard-input`, `mouse-input`, `gamepad-input`), each exercising every action type against real DOM events (a mocked `navigator.getGamepads` for the polled gamepad source, since Playwright has no gamepad emulation).

- **Action types**: `TriggerAction`, `HoldAction`, `Axis1dAction`, `Axis2dAction` — driven by real `page.keyboard`/`page.mouse` events and a fake polled `Gamepad`, asserted against both ECS state and actual rendered pixels (not logic state alone).
- **Action reset types**: `actionResetTypes.zero` vs `noReset`, including the documented pitfalls of misusing each — a held key with the default `zero` reset "twitches" (single impulse, then a compensating twitch back on release), and a gamepad axis with `zero` reset reads correctly for exactly one frame then gets permanently stuck at `0` because the source's own change-detection cache never notices the reset happened underneath it. Both are asserted as regression tests, not just described.
- **Input groups**: `InputManager.setActiveGroup` gating, proven by binding two actions in different groups to the *same* physical key/button/axis and confirming only the active group's action responds.

### Bug found and fixed along the way

Writing the mouse group-gating test surfaced a real bug: `MouseInputSource`'s trigger handlers called `binding.action.trigger()` directly instead of going through `InputManager.dispatchTriggerAction`, bypassing active-group gating entirely — unlike `KeyboardInputSource`, which already routes correctly, and unlike the documented contract in `actions.md`. Fixed in `mouse-input-source.ts`, with a new unit test file (`MouseInputSource` had none before) covering the regression, plus the mouse e2e test that would otherwise fail without the fix (verified locally by reverting the fix and re-running — it fails as expected).

## Test plan

- [x] `npm run check-types`
- [x] `npm test` (1067 tests, including the new `mouse-input-source.test.ts`)
- [x] `npm run lint` (0 errors)
- [x] `npm run cspell` (0 issues)
- [x] `npm run check-exports`
- [x] `npx eslint`/`tsc --noEmit --project e2e/tsconfig.json` on all new `/e2e` files
- [x] Full `/e2e` suite (16 tests across 4 spec files) run twice locally, all green
- [x] Confirmed the mouse group-gating test actually fails without the source fix (regression coverage verified, not assumed)
- [x] `documentation-site`: `npm run build` + `npm run typecheck` pass; manually loaded the `space-shooter` demo (uses `/input`) in a headless browser — renders cleanly, no console errors, keyboard input still drives the ship
- [x] `CHANGELOG.md` updated under `[Unreleased] > Fixed`
- [x] `AGENTS.md` updated with the gamepad-mocking pattern and the polling-cache step-timing gotcha for future e2e authors

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG9K1WR1VXdsUGDCbzh64L)_