### PR TITLE
refactor: finish ECS system batched-update migration (systems, demos, docs, tests)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,26 +76,38 @@ Each module has an `index.ts` file that exports its public API.
 
 ### Entity-Component-System (ECS)
 
-The codebase follows the ECS pattern:
+The codebase follows a data-oriented ECS pattern built from plain objects and
+factory functions, not classes:
 
-1. **Components** (`Component`): Pure data containers extending the abstract `Component` class
-   - Each component class has a unique `id` (symbol) generated automatically
-   - Components are lightweight and contain no logic
+1. **Components**: Plain data interfaces, not classes. Each one gets a
+   `createComponentId` key (a symbol) and an `add<Name>Component` factory
+   that attaches it to a caller-supplied entity (see "Component Pattern"
+   below). Components carry no logic.
 
-2. **Systems** (`System`): Logic processors extending the abstract `System` class
-   - Systems have a `query` defining which components they operate on
-   - Systems implement the `run(entity: Entity)` method
-   - Optional lifecycle methods: `beforeAll()`, `stop()`
-   - Each system has a unique `id` (symbol) generated automatically
+2. **Systems** (`EcsSystem<TQuery>`): Plain objects, produced by
+   `create<Name>EcsSystem` factory functions, not classes. A system declares
+   a `query` (the component keys it reads, in order) and an optional set of
+   `tags`, and implements `update(world, queryResult)`. `queryResult` is a
+   batch for the whole tick - `entities: readonly number[]` and a
+   `components` array (one array per queried component type, in query
+   order) - so `update` runs exactly once per tick regardless of how many
+   entities matched (including zero), and the system iterates the batch
+   itself. An optional `cleanup(world)` hook runs once when the system is
+   removed from an `EcsWorld` or the world is stopped. See "System Pattern"
+   below and `/documentation-site/docs/docs/ecs/system.md`.
 
-3. **Entities** (`Entity`): Containers for components
-   - Entities are created with `new Entity(world, components, options)`
-   - Components are added/removed dynamically
-   - Entities can have parent-child relationships
+3. **Entities**: Just numeric ids (`number`), created with
+   `EcsWorld.createEntity()`. Components are attached/detached by id via the
+   world (`addComponent`/`removeComponent`/`addTag`); there is no `Entity`
+   object. Parent-child relationships are expressed via a
+   `ParentEcsComponent` referencing another entity's id, not object
+   containment.
 
-4. **World** (`World`): Container for entities and systems
-   - Manages entity lifecycle
-   - Routes entities to appropriate systems based on queries
+4. **World** (`EcsWorld`): Container for component data and registered
+   systems. Stores component data grouped by component key, runs each
+   registered system's `update` once per `EcsWorld.update()` tick (in
+   registration-order), and exposes `query(componentKeys, tags?)` for
+   ad-hoc lookups outside of a system's own `query`.
 
 ### Key Patterns
 
@@ -146,7 +158,7 @@ The codebase follows the ECS pattern:
 **Type Safety**:
 
 - Use strict TypeScript mode (already enabled in `tsconfig.base.json`)
-- Always specify return types for functions: `public run(entity: Entity): void`
+- Always specify return types for functions: `update(world: EcsWorld, queryResult: QueryResult<T>): void`
 - Avoid `any`; use `unknown` if necessary
 - Avoid null assertions and casting
 - Types should be narrowed and nullish values should be handled appropriately (usually by throwing an error if it makes sense to do so)
@@ -235,31 +247,31 @@ aggregate-factory example.
 
 ### System Pattern
 
+Systems are plain objects produced by a `create<Name>EcsSystem` factory, not
+classes. `update` receives the whole tick's batch of matches at once
+(`entities` plus one `components` array per queried component type, in query
+order) and iterates it itself:
+
 ```typescript
-import { Entity, System } from '../ecs/index.js';
-import { MyComponent } from '../components/my-component.js';
+import { EcsSystem } from '../../ecs/index.js';
+import { MyComponent, myComponentId } from '../components/my-component.js';
 
 /**
- * Description of what this system does.
+ * Creates a system that processes every entity with a `MyComponent`.
+ * @returns The ECS system.
  */
-export class MySystem extends System {
-  /**
-   * Creates a new MySystem instance.
-   */
-  constructor() {
-    super([MyComponent], 'mySystemName');
-  }
-
-  /**
-   * Processes a single entity.
-   * @param entity - The entity to process.
-   */
-  public run(entity: Entity): void {
-    const component = entity.getComponentRequired(MyComponent);
-    // Process component data
-  }
-}
+export const createMyEcsSystem = (): EcsSystem<[MyComponent]> => ({
+  query: [myComponentId],
+  update: (world, { components: [myComponents] }) => {
+    for (const myComponent of myComponents) {
+      // Process component data
+    }
+  },
+});
 ```
+
+See `/documentation-site/docs/docs/ecs/system.md` for the full contract,
+including the optional `tags` and `cleanup` fields.
 
 ### Index Files
 

--- a/documentation-site/docs/docs/ecs/system.md
+++ b/documentation-site/docs/docs/ecs/system.md
@@ -4,95 +4,77 @@ sidebar_position: 5
 
 # System
 
-A system is a plain object that declares a `query` (an array of component keys), an optional set of `tags`, and a `run` method. The `run` method is called for each matching entity and receives a `QueryResult` object and the `EcsWorld` instance.
-
-Optional `beforeQuery(world)` can return a value that will be passed to `run` as `beforeQueryResult` for every matching entity (useful for expensive, shared pre-computations).
+A system is a plain object that declares a `query` (an array of component keys), an optional set of `tags`, and an `update` method. `update` is called once per tick with every entity currently matching `query` (and `tags`), batched together: an `entities` array of matched entity ids, and a `components` array holding one array per queried component type (in query order), so `components[0][i]` is the component at `query[0]` for `entities[i]`.
 
 Example:
 
 ```ts
 const movementSystem = {
   query: [Position, Velocity] as const,
-  beforeQuery(world) {
-    // compute something once per frame if needed
-    return null;
-  },
-  run(result, world, _before) {
-    const [pos, vel] = result.components as [
-      { x: number; y: number },
-      { x: number; y: number },
-    ];
-    pos.x += vel.x;
-    pos.y += vel.y;
+  update(world, { entities, components: [positions, velocities] }) {
+    for (let i = 0; i < entities.length; i++) {
+      positions[i].x += velocities[i].x;
+      positions[i].y += velocities[i].y;
+    }
   },
 };
 
 world.addSystem(movementSystem);
 ```
 
-## Preprocessing
+## Batching, not per-entity dispatch
 
-Systems may implement an optional `beforeQuery(world)` method. It is invoked once per tick before entity iteration and may return a value that will be passed to `run` as `beforeQueryResult` for every matching entity. Use this to compute expensive, shared data (for example spatial queries or cached lookups) that would be wasteful to recompute per entity. Keep preprocessing fast and preferably side-effect free.
+Unlike some ECS designs, `update` is a single call per tick, not one call per matched entity - the system is responsible for iterating `entities`/`components` itself. This makes cross-entity work (spatial partitioning, sorting, batching draw calls, or anything else that needs to see the whole tick's matches together) straightforward, since there's no separate "preprocess" or "postprocess" hook to reach for: it all happens in the body of `update`.
 
-## Atomicity
-
-Treat each call to `run(result, world, beforeQueryResult)` as a single, focused update for the matched entity. Systems should perform short, deterministic operations and avoid long-running or blocking work inside `run`.
-
-Mutations to world state (adding or removing components or entities) take effect immediately and may be visible to subsequent systems or later iterations. Because of this, do not rely on implicit ordering between systems for coordination; prefer explicit events or deferred work when systems need to coordinate complex state changes.
-
-## Postprocessing the whole tick's results: afterRun
-
-Systems may implement an optional `afterRun(inputs)` method. It is invoked once per tick, after `run` has finished running for every matched entity, with an array of every one of those calls' return values, in query order (empty if nothing matched). It is a genuine once-per-tick hook: all of `run` happens first, then `afterRun` runs exactly once, never interleaved with `run` on a per-entity basis.
-
-This matters for systems whose real work depends on seeing the whole tick's entities together, not just one at a time, most notably the render system: each camera entity's `run` computes that camera's projection matrix and gathers the sprites it should draw into its own command list, and `afterRun` draws every camera's batch once all of them are known, from a single, predictable pass over the results.
+For example, the render system gathers every camera's sprite commands and computes its projection matrix in the same `update` call that ultimately issues that camera's draw calls, once all of the tick's cameras are known:
 
 ```ts
-interface RenderPassResult {
-  projectionMatrix: Matrix3x3;
-  target: RenderTarget | null;
-  commands: RenderCommand[];
-}
-
-const system: EcsSystem<[Camera], null, RenderPassResult> = {
+const system: EcsSystem<[Camera]> = {
   query: [Camera],
-  run(result) {
-    // ...compute this camera's pass, don't draw anything yet...
-    return { projectionMatrix, target, commands };
-  },
-  afterRun(results) {
-    for (const { projectionMatrix, target, commands } of results) {
-      // ...draw each camera's pass, now that every camera is known...
+  update(world, { components: [cameras] }) {
+    for (const camera of cameras) {
+      // ...compute this camera's pass and issue its draw calls...
     }
   },
 };
 ```
 
-If a system doesn't need this, leave off `afterRun` entirely and don't return anything from `run`; the corresponding type parameter defaults to `void`, so `run` can end without an explicit `return` statement like any other `(...): void` function.
+If a system needs to run some logic exactly once per tick regardless of how many entities match (or even when nothing matches), just do that work directly in `update` rather than per matched entity - `update` already runs exactly once per tick, whether `entities` has zero, one, or many ids in it.
 
-## Releasing resources when the world stops: cleanupEntities
+## Atomicity
 
-Systems may implement an optional `cleanupEntities(queryResult, world)` method. It runs once for every entity still matching the system's `query` (and `tags`) when the owning world is stopped, most commonly because a [`Game`](./game.md) was stopped. It is not called per-tick, only on shutdown, so it's the place to release resources the system itself acquired for an entity, resources that a component's own lifecycle doesn't already handle.
+Treat each call to `update(world, queryResult)` as a single, focused update for the tick's batch of matched entities. Systems should perform short, deterministic operations and avoid long-running or blocking work inside `update`.
+
+`queryResult.entities` and `queryResult.components` are snapshots computed before `update` is called, so it's safe to mutate world state (adding/removing components or entities) while iterating them - the arrays you're looping over won't change out from under you. Mutations still take effect immediately and may be visible to subsequent systems this same tick or on later iterations. Because of this, do not rely on implicit ordering between systems for coordination; prefer explicit events or deferred work when systems need to coordinate complex state changes.
+
+## Releasing resources: cleanup
+
+Systems may implement an optional `cleanup(world)` method. It runs once - not per entity - both when the system is removed via `EcsWorld.removeSystem` and when the owning world is stopped via `EcsWorld.stop` (most commonly because a [`Game`](./game.md) was stopped). It's the place to release resources the system itself acquired, resources that a component's own lifecycle doesn't already handle.
+
+Since `cleanup` doesn't receive a query result, a system that needs to release a resource per matched entity should track what it acquired itself (for example in a `Map` keyed by entity id) rather than re-querying the world:
 
 ```ts
 const audioSystem: EcsSystem<[AudioComponent]> = {
   query: [Audio],
-  run(result) {
-    const [audio] = result.components;
-
-    if (audio.playSound) {
-      audio.sound.play();
-      audio.playSound = false;
+  update(world, { components: [audioComponents] }) {
+    for (const audio of audioComponents) {
+      if (audio.playSound) {
+        audio.sound.play();
+        audio.playSound = false;
+      }
     }
   },
-  cleanupEntities(result) {
-    const [audio] = result.components;
+  cleanup(world) {
+    const { components: [audioComponents] } = world.query<[AudioComponent]>([Audio]);
 
-    if (audio.sound.playing()) {
-      audio.sound.stop();
-      audio.sound.unload();
+    for (const audio of audioComponents) {
+      if (audio.sound.playing()) {
+        audio.sound.stop();
+        audio.sound.unload();
+      }
     }
   },
 };
 ```
 
-Other systems use `cleanupEntities` to remove a physics body from the physics world, or to dispose scratch GPU render targets that a system allocates outside of any component (see the gaussian blur system for an example of the latter). If a system doesn't acquire any per-entity resources, leave `cleanupEntities` off.
+Other systems use `cleanup` to remove physics bodies/joints from the physics world (tracking a `Map<entity, RigidBody>` of what they registered, so `cleanup` only has to iterate that map), or to dispose scratch GPU render targets that a system allocates outside of any component (see the gaussian blur system for an example of the latter). If a system doesn't acquire any resources beyond its components, leave `cleanup` off.

--- a/documentation-site/docs/docs/ecs/world.md
+++ b/documentation-site/docs/docs/ecs/world.md
@@ -73,21 +73,22 @@ world.addTag(entity, Enemy);
 
 Tags differ from normal components in that they carry no payload (they are stored
 internally as a boolean) and are not returned as part of the `components` array
-passed to a system's `run` method. They are similar in that they are indexed by
+passed to a system's `update` method. They are similar in that they are indexed by
 the world and can be used in queries. See the [Component docs](component.md)
 for details on component keys and tag creation.
 
 ## Querying for entities
 
-You can query the world directly for entity ids that have a set of component keys
-using `queryEntities(componentKeys, outArray)`. Pass an array to collect results.
+You can query the world directly for entity ids (and their component data) that
+have a set of component keys using `query(componentKeys, tags?)`. It returns an
+object with an `entities` array and a `components` array (one array per queried
+component key, in query order).
 
 ```ts
-const out: number[] = [];
-world.queryEntities([Position], out);
-for (const id of out) {
-  const position = world.getComponent(id, Position);
-  // do something with position
+const { entities, components: [positions] } = world.query([Position]);
+
+for (let i = 0; i < entities.length; i++) {
+  // do something with positions[i]
 }
 ```
 
@@ -97,26 +98,26 @@ logic that should live in a system is being executed ad-hoc; consult the
 [Component docs](component.md) for patterns.
 
 :::caution
-Calling `queryEntities` frequently or on large component sets can be
+Calling `query` frequently or on large component sets can be
 expensive. Use systems with declared `query` arrays for per-frame processing.
 :::
 
 ## Add a system
 
 Create a system object that declares a `query` (component keys), optional `tags`,
-an optional `beforeQuery(world)` and a `run(result, world, beforeQueryResult)`
-method. Register it with `addSystem(system, registrationOrder)`.
+and an `update(world, queryResult)` method. Register it with
+`addSystem(system, registrationOrder)`.
 
 ```ts
 import { SystemRegistrationOrder } from '@forge-game-engine/forge/ecs';
 
 const moverSystem = {
   query: [Position, Velocity] as const,
-  run(result, world) {
-    const [position, velocity] = result.components;
-
-    position.x += velocity.x;
-    position.y += velocity.y;
+  update(world, { entities, components: [positions, velocities] }) {
+    for (let i = 0; i < entities.length; i++) {
+      positions[i].x += velocities[i].x;
+      positions[i].y += velocities[i].y;
+    }
   },
 };
 
@@ -157,9 +158,10 @@ it will still run as part of the current tick. The removal is only committed at 
 
 ## Executing a world tick
 
-Call `world.update()` to run the registered systems for a single frame. The
-world calls each system's `beforeQuery` (if present) and then iterates matching
-entities, invoking the system's `run` for each match.
+Call `world.update()` to run the registered systems for a single frame. For
+each registered system, the world queries `query` (and `tags`) and invokes the
+system's `update` exactly once with the batch of matches, regardless of how
+many entities matched (including zero).
 
 In normal usage you don't call `update()` manually. The main loop in `Game` calls it for you every frame. Calling `update()` directly is useful for unit tests.
 
@@ -186,9 +188,10 @@ world.addComponent(entity, Position, { x: 12, y: 10 });
 
 const logPositionSystem = {
   query: [Position],
-  run(result) {
-    const [position] = result.components;
-    console.log(`position: [${position.x}, ${position.y}]`); // prints: "position: [12, 10]" every frame
+  update(world, { components: [positions] }) {
+    for (const position of positions) {
+      console.log(`position: [${position.x}, ${position.y}]`); // prints: "position: [12, 10]" every frame
+    }
   },
 };
 

--- a/documentation-site/docs/docs/events/custom-events.md
+++ b/documentation-site/docs/docs/events/custom-events.md
@@ -57,19 +57,20 @@ changes:
 ```ts
 const damageSystem = {
   query: [Health] as const,
-  run(result, world) {
-    const [health] = result.components as [HealthComponent];
-    const damage = getIncomingDamage(); // however this is determined
+  update(world, { components: [healthComponents] }) {
+    for (const health of healthComponents as HealthComponent[]) {
+      const damage = getIncomingDamage(); // however this is determined
 
-    if (damage <= 0) {
-      return;
-    }
+      if (damage <= 0) {
+        continue;
+      }
 
-    health.current = Math.max(0, health.current - damage);
-    health.onDamaged.raise(damage);
+      health.current = Math.max(0, health.current - damage);
+      health.onDamaged.raise(damage);
 
-    if (health.current === 0) {
-      health.onDied.raise();
+      if (health.current === 0) {
+        health.onDied.raise();
+      }
     }
   },
 };
@@ -106,7 +107,7 @@ run for that `raise()` call, and the error propagates to whoever called
 ### Create events once, not every frame
 
 `ForgeEvent` and `ParameterizedForgeEvent` instances hold their listeners
-internally. Creating a new instance inside `run()` or another per-frame path
+internally. Creating a new instance inside `update()` or another per-frame path
 discards every listener that was previously registered. Create the event
 once, as part of the component's initial data or in a constructor, and call
 `raise()` on that same instance repeatedly.
@@ -132,12 +133,12 @@ inspection, for example in tests, but make changes through
 ❌ Recreating the event loses every previously registered listener:
 
 ```ts
-run(result, world) {
-  const [health] = result.components as [HealthComponent];
-
-  // a fresh event every tick, nobody is listening to this one
-  health.onDamaged = new ParameterizedForgeEvent<number>('player-damaged');
-  health.onDamaged.raise(damage);
+update(world, { components: [healthComponents] }) {
+  for (const health of healthComponents as HealthComponent[]) {
+    // a fresh event every tick, nobody is listening to this one
+    health.onDamaged = new ParameterizedForgeEvent<number>('player-damaged');
+    health.onDamaged.raise(damage);
+  }
 }
 ```
 

--- a/documentation-site/docs/docs/input/index.md
+++ b/documentation-site/docs/docs/input/index.md
@@ -97,14 +97,14 @@ import {
 
 const playerMovementSystem: EcsSystem<[PositionEcsComponent]> = {
   query: [positionId],
-  run: (result) => {
-    const [position] = result.components;
+  update: (world, { components: [positions] }) => {
+    for (const position of positions) {
+      position.local.x += move.value.x * 100 * time.deltaTimeInSeconds;
+      position.local.y += move.value.y * 100 * time.deltaTimeInSeconds;
 
-    position.local.x += move.value.x * 100 * time.deltaTimeInSeconds;
-    position.local.y += move.value.y * 100 * time.deltaTimeInSeconds;
-
-    if (jump.isTriggered) {
-      // apply a jump impulse, play a sound, etc.
+      if (jump.isTriggered) {
+        // apply a jump impulse, play a sound, etc.
+      }
     }
   },
 };

--- a/documentation-site/docs/docs/math/angles-and-rotation.md
+++ b/documentation-site/docs/docs/math/angles-and-rotation.md
@@ -86,14 +86,17 @@ import { vectorToRadians } from '@forge-game-engine/forge/math';
 
 const faceVelocitySystem = {
   query: [velocityId, rotationId] as const,
-  run(result) {
-    const [velocity, rotation] = result.components;
+  update(world, { components: [velocities, rotations] }) {
+    for (let i = 0; i < velocities.length; i++) {
+      const velocity = velocities[i];
+      const rotation = rotations[i];
 
-    if (velocity.value.magnitudeSquared() < 0.0001) {
-      return;
+      if (velocity.value.magnitudeSquared() < 0.0001) {
+        continue;
+      }
+
+      rotation.local = vectorToRadians(velocity.value) + Math.PI / 2;
     }
-
-    rotation.local = vectorToRadians(velocity.value) + Math.PI / 2;
   },
 };
 ```

--- a/documentation-site/docs/docs/math/interpolation-and-smoothing.md
+++ b/documentation-site/docs/docs/math/interpolation-and-smoothing.md
@@ -64,20 +64,23 @@ import { smoothDampVector2 } from '@forge-game-engine/forge/math';
 
 const cameraFollowSystem = {
   query: [cameraId, positionId] as const,
-  run(result, _world, _before) {
-    const [camera, position] = result.components;
+  update(world, { components: [cameras, positions] }) {
+    for (let i = 0; i < cameras.length; i++) {
+      const camera = cameras[i];
+      const position = positions[i];
 
-    const { positionOutput, velocityOutput } = smoothDampVector2(
-      camera.position,
-      position.world,
-      camera.velocity,
-      camera.maxFollowSpeed,
-      camera.followSmoothTime,
-      deltaTimeInSeconds,
-    );
+      const { positionOutput, velocityOutput } = smoothDampVector2(
+        camera.position,
+        position.world,
+        camera.velocity,
+        camera.maxFollowSpeed,
+        camera.followSmoothTime,
+        deltaTimeInSeconds,
+      );
 
-    camera.position = positionOutput;
-    camera.velocity = velocityOutput;
+      camera.position = positionOutput;
+      camera.velocity = velocityOutput;
+    }
   },
 };
 ```

--- a/documentation-site/docs/docs/math/vectors.md
+++ b/documentation-site/docs/docs/math/vectors.md
@@ -137,19 +137,24 @@ const seekSpeed = 120; // pixels per second
 
 const seekSystem = {
   query: [positionId, targetId] as const,
-  run(result) {
-    const [position, target] = result.components;
+  update(world, { components: [positions, targets] }) {
+    for (let i = 0; i < positions.length; i++) {
+      const position = positions[i];
+      const target = targets[i];
 
-    const toTarget = target.value.subtract(position.world);
-    const distance = toTarget.magnitude();
+      const toTarget = target.value.subtract(position.world);
+      const distance = toTarget.magnitude();
 
-    if (distance < 1) {
-      return;
+      if (distance < 1) {
+        continue;
+      }
+
+      const step = toTarget
+        .normalize()
+        .multiply(seekSpeed * deltaTimeInSeconds);
+
+      position.world = position.world.add(step);
     }
-
-    const step = toTarget.normalize().multiply(seekSpeed * deltaTimeInSeconds);
-
-    position.world = position.world.add(step);
   },
 };
 ```

--- a/documentation-site/src/pages/demos/brick-breaker/_background.system.ts
+++ b/documentation-site/src/pages/demos/brick-breaker/_background.system.ts
@@ -11,12 +11,12 @@ export const createBackgroundEcsSystem = (
 ): EcsSystem<[SpriteEcsComponent]> => ({
   query: [spriteId],
   tags: [backgroundId],
-  run: (result) => {
-    const [spriteComponent] = result.components;
-
-    spriteComponent.renderable.material.setUniform(
-      'u_time',
-      time.timeInSeconds,
-    );
+  update: (_world, { components: [spriteComponents] }) => {
+    for (const spriteComponent of spriteComponents) {
+      spriteComponent.renderable.material.setUniform(
+        'u_time',
+        time.timeInSeconds,
+      );
+    }
   },
 });

--- a/documentation-site/src/pages/demos/brick-breaker/_ball.system.ts
+++ b/documentation-site/src/pages/demos/brick-breaker/_ball.system.ts
@@ -8,6 +8,7 @@ import {
   PhysicsBodyEcsComponent,
   PhysicsBodyId,
   PhysicsWorld,
+  RigidBody,
 } from '@forge-game-engine/forge/physics';
 import { BallEcsComponent, ballId } from './_ball.component';
 import { launchBall } from './_create-ball';
@@ -22,27 +23,41 @@ export const createBallEcsSystem = (
   [BallEcsComponent, PositionEcsComponent, PhysicsBodyEcsComponent]
 > => ({
   query: [ballId, positionId, PhysicsBodyId],
-  run: (result) => {
-    const [ballComponent, positionComponent, physicsBodyComponent] =
-      result.components;
-    const { physicsBody } = physicsBodyComponent;
+  update: (
+    _world,
+    { components: [ballComponents, positionComponents, physicsBodyComponents] },
+  ) => {
+    for (let i = 0; i < ballComponents.length; i++) {
+      const ballComponent = ballComponents[i];
+      const positionComponent = positionComponents[i];
+      const physicsBodyComponent = physicsBodyComponents[i];
+      const { physicsBody } = physicsBodyComponent;
 
-    for (const { bodyA, bodyB } of physicsWorld.collisionStarts) {
-      if (bodyA !== physicsBody && bodyB !== physicsBody) {
-        continue;
+      destroyCollidedBricks(physicsWorld, physicsBody, brickField);
+
+      if (positionComponent.world.y < missY) {
+        physicsBody.position = ballComponent.startPosition.clone();
+        positionComponent.world = ballComponent.startPosition.clone();
+        launchBall(physicsBody, ballComponent.speed, random);
       }
-
-      const otherEntity = (bodyA === physicsBody ? bodyB : bodyA).userData;
-
-      if (typeof otherEntity === 'number' && brickField.has(otherEntity)) {
-        brickField.destroy(otherEntity);
-      }
-    }
-
-    if (positionComponent.world.y < missY) {
-      physicsBody.position = ballComponent.startPosition.clone();
-      positionComponent.world = ballComponent.startPosition.clone();
-      launchBall(physicsBody, ballComponent.speed, random);
     }
   },
 });
+
+const destroyCollidedBricks = (
+  physicsWorld: PhysicsWorld,
+  physicsBody: RigidBody,
+  brickField: BrickField,
+): void => {
+  for (const { bodyA, bodyB } of physicsWorld.collisionStarts) {
+    if (bodyA !== physicsBody && bodyB !== physicsBody) {
+      continue;
+    }
+
+    const otherEntity = (bodyA === physicsBody ? bodyB : bodyA).userData;
+
+    if (typeof otherEntity === 'number' && brickField.has(otherEntity)) {
+      brickField.destroy(otherEntity);
+    }
+  }
+};

--- a/documentation-site/src/pages/demos/brick-breaker/_brick.system.ts
+++ b/documentation-site/src/pages/demos/brick-breaker/_brick.system.ts
@@ -11,12 +11,12 @@ export const createBrickEcsSystem = (
 ): EcsSystem<[SpriteEcsComponent]> => ({
   query: [spriteId],
   tags: [brickId],
-  run: (result) => {
-    const [spriteComponent] = result.components;
-
-    spriteComponent.renderable.material.setUniform(
-      'u_time',
-      time.timeInSeconds,
-    );
+  update: (_world, { components: [spriteComponents] }) => {
+    for (const spriteComponent of spriteComponents) {
+      spriteComponent.renderable.material.setUniform(
+        'u_time',
+        time.timeInSeconds,
+      );
+    }
   },
 });

--- a/documentation-site/src/pages/demos/brick-breaker/_paddle.system.ts
+++ b/documentation-site/src/pages/demos/brick-breaker/_paddle.system.ts
@@ -13,15 +13,18 @@ export const createPaddleEcsSystem = (
   time: Time,
 ): EcsSystem<[PaddleEcsComponent, PositionEcsComponent]> => ({
   query: [paddleId, positionId],
-  run: (result) => {
-    const [paddleComponent, positionComponent] = result.components;
-    const { speed, minX, maxX } = paddleComponent;
+  update: (_world, { components: [paddleComponents, positionComponents] }) => {
+    for (let i = 0; i < paddleComponents.length; i++) {
+      const paddleComponent = paddleComponents[i];
+      const positionComponent = positionComponents[i];
+      const { speed, minX, maxX } = paddleComponent;
 
-    positionComponent.world.x = clamp(
-      positionComponent.world.x +
-        moveAction.value * speed * time.deltaTimeInSeconds,
-      minX,
-      maxX,
-    );
+      positionComponent.world.x = clamp(
+        positionComponent.world.x +
+          moveAction.value * speed * time.deltaTimeInSeconds,
+        minX,
+        maxX,
+      );
+    }
   },
 });

--- a/documentation-site/src/pages/demos/car/_air-control.system.ts
+++ b/documentation-site/src/pages/demos/car/_air-control.system.ts
@@ -27,34 +27,35 @@ export const createAirControlEcsSystem = (
   time: Time,
 ): EcsSystem<[AirControlEcsComponent]> => ({
   query: [airControlId],
-  run: (result) => {
-    const [airControl] = result.components;
-    const { frontWheelGroundContact, rearWheelGroundContact } = airControl;
+  update: (_world, { components: [airControls] }) => {
+    for (const airControl of airControls) {
+      const { frontWheelGroundContact, rearWheelGroundContact } = airControl;
 
-    if (
-      isGrounded(frontWheelGroundContact) ||
-      isGrounded(rearWheelGroundContact)
-    ) {
-      return;
+      if (
+        isGrounded(frontWheelGroundContact) ||
+        isGrounded(rearWheelGroundContact)
+      ) {
+        continue;
+      }
+
+      const { chassisBody, throttleInput, maxAngularSpeed, maxTorque } =
+        airControl;
+      const { deltaTimeInSeconds } = time;
+
+      const responsiveness = chassisBody.inverseInertia * deltaTimeInSeconds;
+
+      if (responsiveness <= 0) {
+        continue;
+      }
+
+      const targetAngularVelocity = throttleInput.value * maxAngularSpeed;
+
+      const desiredTorque =
+        (targetAngularVelocity - chassisBody.angularVelocity) / responsiveness;
+
+      const torque = clamp(desiredTorque, -maxTorque, maxTorque);
+
+      chassisBody.applyTorque(torque, deltaTimeInSeconds);
     }
-
-    const { chassisBody, throttleInput, maxAngularSpeed, maxTorque } =
-      airControl;
-    const { deltaTimeInSeconds } = time;
-
-    const responsiveness = chassisBody.inverseInertia * deltaTimeInSeconds;
-
-    if (responsiveness <= 0) {
-      return;
-    }
-
-    const targetAngularVelocity = throttleInput.value * maxAngularSpeed;
-
-    const desiredTorque =
-      (targetAngularVelocity - chassisBody.angularVelocity) / responsiveness;
-
-    const torque = clamp(desiredTorque, -maxTorque, maxTorque);
-
-    chassisBody.applyTorque(torque, deltaTimeInSeconds);
   },
 });

--- a/documentation-site/src/pages/demos/car/_camera-follow.system.ts
+++ b/documentation-site/src/pages/demos/car/_camera-follow.system.ts
@@ -22,24 +22,30 @@ export const createCameraFollowEcsSystem = (
   time: Time,
 ): EcsSystem<[CameraFollowEcsComponent, PositionEcsComponent]> => ({
   query: [cameraFollowId, positionId],
-  run: (result) => {
-    const [cameraFollow, positionComponent] = result.components;
-    const { target, offset, smoothTime, maxSpeed, velocity } = cameraFollow;
+  update: (
+    _world,
+    { components: [cameraFollowComponents, positionComponents] },
+  ) => {
+    for (let i = 0; i < cameraFollowComponents.length; i++) {
+      const cameraFollow = cameraFollowComponents[i];
+      const positionComponent = positionComponents[i];
+      const { target, offset, smoothTime, maxSpeed, velocity } = cameraFollow;
 
-    const { positionOutput, velocityOutput } = smoothDampVector2(
-      positionComponent.local,
-      target.position.add(offset),
-      velocity,
-      maxSpeed,
-      smoothTime,
-      time.deltaTimeInSeconds,
-    );
+      const { positionOutput, velocityOutput } = smoothDampVector2(
+        positionComponent.local,
+        target.position.add(offset),
+        velocity,
+        maxSpeed,
+        smoothTime,
+        time.deltaTimeInSeconds,
+      );
 
-    cameraFollow.velocity = velocityOutput;
+      cameraFollow.velocity = velocityOutput;
 
-    positionComponent.local.x = positionOutput.x;
-    positionComponent.local.y = positionOutput.y;
-    positionComponent.world.x = positionOutput.x;
-    positionComponent.world.y = positionOutput.y;
+      positionComponent.local.x = positionOutput.x;
+      positionComponent.local.y = positionOutput.y;
+      positionComponent.world.x = positionOutput.x;
+      positionComponent.world.y = positionOutput.y;
+    }
   },
 });

--- a/documentation-site/src/pages/demos/car/_car-reset.system.ts
+++ b/documentation-site/src/pages/demos/car/_car-reset.system.ts
@@ -14,18 +14,18 @@ export const createCarResetEcsSystem = (): EcsSystem<
   [CarResetEcsComponent]
 > => ({
   query: [carResetId],
-  run: (result) => {
-    const [carReset] = result.components;
+  update: (_world, { components: [carResets] }) => {
+    for (const carReset of carResets) {
+      if (!carReset.restartInput.isTriggered) {
+        continue;
+      }
 
-    if (!carReset.restartInput.isTriggered) {
-      return;
-    }
-
-    for (const { body, initialPosition, initialAngle } of carReset.bodies) {
-      body.position = initialPosition.clone();
-      body.angle = initialAngle;
-      body.velocity = Vector2.zero;
-      body.angularVelocity = 0;
+      for (const { body, initialPosition, initialAngle } of carReset.bodies) {
+        body.position = initialPosition.clone();
+        body.angle = initialAngle;
+        body.velocity = Vector2.zero;
+        body.angularVelocity = 0;
+      }
     }
   },
 });

--- a/documentation-site/src/pages/demos/car/_chassis-stabilizer.system.ts
+++ b/documentation-site/src/pages/demos/car/_chassis-stabilizer.system.ts
@@ -23,23 +23,25 @@ export const createChassisStabilizerEcsSystem = (
   time: Time,
 ): EcsSystem<[ChassisStabilizerEcsComponent]> => ({
   query: [chassisStabilizerId],
-  run: (result) => {
-    const [stabilizer] = result.components;
-    const { frontWheelGroundContact, rearWheelGroundContact } = stabilizer;
+  update: (_world, { components: [stabilizers] }) => {
+    for (const stabilizer of stabilizers) {
+      const { frontWheelGroundContact, rearWheelGroundContact } = stabilizer;
 
-    if (
-      !isGrounded(frontWheelGroundContact) &&
-      !isGrounded(rearWheelGroundContact)
-    ) {
-      return;
+      if (
+        !isGrounded(frontWheelGroundContact) &&
+        !isGrounded(rearWheelGroundContact)
+      ) {
+        continue;
+      }
+
+      const { body, levelingStiffness, levelingDamping } = stabilizer;
+      const { deltaTimeInSeconds } = time;
+
+      const torque =
+        -body.angle * levelingStiffness -
+        body.angularVelocity * levelingDamping;
+
+      body.applyTorque(torque, deltaTimeInSeconds);
     }
-
-    const { body, levelingStiffness, levelingDamping } = stabilizer;
-    const { deltaTimeInSeconds } = time;
-
-    const torque =
-      -body.angle * levelingStiffness - body.angularVelocity * levelingDamping;
-
-    body.applyTorque(torque, deltaTimeInSeconds);
   },
 });

--- a/documentation-site/src/pages/demos/car/_ground-contact.system.ts
+++ b/documentation-site/src/pages/demos/car/_ground-contact.system.ts
@@ -43,19 +43,20 @@ export const createGroundContactEcsSystem = (
   physicsWorld: PhysicsWorld,
 ): EcsSystem<[GroundContactEcsComponent]> => ({
   query: [groundContactId],
-  run: (result) => {
-    const [groundContact] = result.components;
-    const { body } = groundContact;
+  update: (_world, { components: [groundContacts] }) => {
+    for (const groundContact of groundContacts) {
+      const { body } = groundContact;
 
-    for (const { bodyA, bodyB } of physicsWorld.collisionStarts) {
-      if (isBodyGroundContact(bodyA, bodyB, body)) {
-        groundContact.groundContacts++;
+      for (const { bodyA, bodyB } of physicsWorld.collisionStarts) {
+        if (isBodyGroundContact(bodyA, bodyB, body)) {
+          groundContact.groundContacts++;
+        }
       }
-    }
 
-    for (const { bodyA, bodyB } of physicsWorld.collisionEnds) {
-      if (isBodyGroundContact(bodyA, bodyB, body)) {
-        groundContact.groundContacts--;
+      for (const { bodyA, bodyB } of physicsWorld.collisionEnds) {
+        if (isBodyGroundContact(bodyA, bodyB, body)) {
+          groundContact.groundContacts--;
+        }
       }
     }
   },

--- a/documentation-site/src/pages/demos/car/_wheel-drive.system.ts
+++ b/documentation-site/src/pages/demos/car/_wheel-drive.system.ts
@@ -56,31 +56,35 @@ export const createWheelDriveEcsSystem = (): EcsSystem<
   ]
 > => ({
   query: [wheelDriveId, AngularVelocityMotorId, groundContactId],
-  run: (result) => {
-    const [wheelDrive, motor, groundContact] = result.components;
-    const {
-      throttleInput,
-      chassisBody,
-      wheelRadius,
-      maxWheelSpeed,
-      maxSlipAngularSpeed,
-      maxTorque,
-    } = wheelDrive;
+  update: (_world, { components: [wheelDrives, motors, groundContacts] }) => {
+    for (let i = 0; i < wheelDrives.length; i++) {
+      const wheelDrive = wheelDrives[i];
+      const motor = motors[i];
+      const groundContact = groundContacts[i];
+      const {
+        throttleInput,
+        chassisBody,
+        wheelRadius,
+        maxWheelSpeed,
+        maxSlipAngularSpeed,
+        maxTorque,
+      } = wheelDrive;
 
-    const desiredAngularVelocity = -throttleInput.value * maxWheelSpeed;
+      const desiredAngularVelocity = -throttleInput.value * maxWheelSpeed;
 
-    if (isGrounded(groundContact)) {
-      motor.targetVelocity = desiredAngularVelocity;
-    } else {
-      const rollingAngularVelocity = -chassisBody.velocity.x / wheelRadius;
+      if (isGrounded(groundContact)) {
+        motor.targetVelocity = desiredAngularVelocity;
+      } else {
+        const rollingAngularVelocity = -chassisBody.velocity.x / wheelRadius;
 
-      motor.targetVelocity = clamp(
-        desiredAngularVelocity,
-        rollingAngularVelocity - maxSlipAngularSpeed,
-        rollingAngularVelocity + maxSlipAngularSpeed,
-      );
+        motor.targetVelocity = clamp(
+          desiredAngularVelocity,
+          rollingAngularVelocity - maxSlipAngularSpeed,
+          rollingAngularVelocity + maxSlipAngularSpeed,
+        );
+      }
+
+      motor.maxTorque = throttleInput.value === 0 ? 0 : maxTorque;
     }
-
-    motor.maxTorque = throttleInput.value === 0 ? 0 : maxTorque;
   },
 });

--- a/documentation-site/src/pages/demos/easing-functions/_easing-row.system.ts
+++ b/documentation-site/src/pages/demos/easing-functions/_easing-row.system.ts
@@ -31,12 +31,15 @@ export const createEasingRowEcsSystem = (
   time: Time,
 ): EcsSystem<[PositionEcsComponent, EasingRowEcsComponent]> => ({
   query: [positionId, easingRowId],
-  run: (result) => {
-    const [position, easingRow] = result.components;
-    const { easingFunction, minX, maxX } = easingRow;
+  update: (_world, { components: [positions, easingRows] }) => {
+    for (let i = 0; i < positions.length; i++) {
+      const position = positions[i];
+      const easingRow = easingRows[i];
+      const { easingFunction, minX, maxX } = easingRow;
 
-    const phase = pingPong(time.timeInSeconds);
+      const phase = pingPong(time.timeInSeconds);
 
-    position.world.x = lerp(minX, maxX, easingFunction(phase));
+      position.world.x = lerp(minX, maxX, easingFunction(phase));
+    }
   },
 });

--- a/documentation-site/src/pages/demos/ecs/_demo.system.ts
+++ b/documentation-site/src/pages/demos/ecs/_demo.system.ts
@@ -11,13 +11,18 @@ export const createDemoEcsSystem = (
   time: Time,
 ): EcsSystem<[PositionEcsComponent, RotationEcsComponent]> => ({
   query: [positionId, rotationId],
-  run: (queryResult) => {
+  update: (_world, queryResult) => {
     const { components } = queryResult;
 
-    const [position, rotation] = components;
+    const [positions, rotations] = components;
 
-    position.world.x = Math.sin(time.timeInSeconds) * 100;
-    position.world.y = Math.cos(time.timeInSeconds) * 100;
-    rotation.world = time.timeInSeconds;
+    for (let i = 0; i < positions.length; i++) {
+      const position = positions[i];
+      const rotation = rotations[i];
+
+      position.world.x = Math.sin(time.timeInSeconds) * 100;
+      position.world.y = Math.cos(time.timeInSeconds) * 100;
+      rotation.world = time.timeInSeconds;
+    }
   },
 });

--- a/documentation-site/src/pages/demos/erosion-burn/_erosion.system.ts
+++ b/documentation-site/src/pages/demos/erosion-burn/_erosion.system.ts
@@ -20,14 +20,14 @@ export const createErosionEcsSystem = (
 ): EcsSystem<[SpriteEcsComponent]> => ({
   query: [spriteId],
   tags: [erosionId],
-  run: (result) => {
-    const [sprite] = result.components;
+  update: (_world, { components: [sprites] }) => {
+    for (const sprite of sprites) {
+      const wave = (Math.sin(time.timeInSeconds * cycleSpeed) + 1) / 2;
 
-    const wave = (Math.sin(time.timeInSeconds * cycleSpeed) + 1) / 2;
-
-    sprite.renderable.material.setUniform(
-      'u_burnProgress',
-      wave * burnRange + burnOffset,
-    );
+      sprite.renderable.material.setUniform(
+        'u_burnProgress',
+        wave * burnRange + burnOffset,
+      );
+    }
   },
 });

--- a/documentation-site/src/pages/demos/linear-spring-damper/_reset.system.ts
+++ b/documentation-site/src/pages/demos/linear-spring-damper/_reset.system.ts
@@ -14,17 +14,17 @@ export const createResetEcsSystem = (
   time: Time,
 ): EcsSystem<[ResetEcsComponent]> => ({
   query: [resetId],
-  run: (result) => {
-    const [reset] = result.components;
+  update: (_world, { components: [resets] }) => {
+    for (const reset of resets) {
+      reset.elapsedSeconds += time.deltaTimeInSeconds;
 
-    reset.elapsedSeconds += time.deltaTimeInSeconds;
+      if (reset.elapsedSeconds < reset.intervalSeconds) {
+        continue;
+      }
 
-    if (reset.elapsedSeconds < reset.intervalSeconds) {
-      return;
+      reset.elapsedSeconds = 0;
+      reset.body.position = reset.initialPosition.clone();
+      reset.body.velocity = reset.initialVelocity.clone();
     }
-
-    reset.elapsedSeconds = 0;
-    reset.body.position = reset.initialPosition.clone();
-    reset.body.velocity = reset.initialVelocity.clone();
   },
 });

--- a/documentation-site/src/pages/demos/linear-spring-damper/_spring-line.system.ts
+++ b/documentation-site/src/pages/demos/linear-spring-damper/_spring-line.system.ts
@@ -21,19 +21,23 @@ export const createSpringLineEcsSystem = (): EcsSystem<
   [SpringLineEcsComponent, PositionEcsComponent, SpriteEcsComponent]
 > => ({
   query: [springLineId, positionId, spriteId],
-  run: (result) => {
-    const [springLine, positionComponent, spriteComponent] = result.components;
-    const { anchorPosition, body, lineWidth } = springLine;
+  update: (_world, { components: [springLines, positions, sprites] }) => {
+    for (let i = 0; i < springLines.length; i++) {
+      const springLine = springLines[i];
+      const positionComponent = positions[i];
+      const spriteComponent = sprites[i];
+      const { anchorPosition, body, lineWidth } = springLine;
 
-    const midpoint = anchorPosition.add(body.position).multiply(0.5);
-    const length = body.position.subtract(anchorPosition).magnitude();
+      const midpoint = anchorPosition.add(body.position).multiply(0.5);
+      const length = body.position.subtract(anchorPosition).magnitude();
 
-    positionComponent.world.x = midpoint.x;
-    positionComponent.world.y = midpoint.y;
-    positionComponent.local.x = midpoint.x;
-    positionComponent.local.y = midpoint.y;
+      positionComponent.world.x = midpoint.x;
+      positionComponent.world.y = midpoint.y;
+      positionComponent.local.x = midpoint.x;
+      positionComponent.local.y = midpoint.y;
 
-    spriteComponent.width = lineWidth;
-    spriteComponent.height = length;
+      spriteComponent.width = lineWidth;
+      spriteComponent.height = length;
+    }
   },
 });

--- a/documentation-site/src/pages/demos/newtons-cradle/_arm.system.ts
+++ b/documentation-site/src/pages/demos/newtons-cradle/_arm.system.ts
@@ -36,25 +36,29 @@ export const createArmEcsSystem = (): EcsSystem<
   ]
 > => ({
   query: [armId, positionId, rotationId, spriteId],
-  run: (result) => {
-    const [arm, positionComponent, rotationComponent, spriteComponent] =
-      result.components;
-    const { pivotPosition, body, armWidth } = arm;
+  update: (_world, { components: [arms, positions, rotations, sprites] }) => {
+    for (let i = 0; i < arms.length; i++) {
+      const arm = arms[i];
+      const positionComponent = positions[i];
+      const rotationComponent = rotations[i];
+      const spriteComponent = sprites[i];
+      const { pivotPosition, body, armWidth } = arm;
 
-    const delta = body.position.subtract(pivotPosition);
-    const length = delta.magnitude();
-    const midpoint = pivotPosition.add(body.position).multiply(0.5);
-    const angle = -Math.atan2(delta.x, -delta.y);
+      const delta = body.position.subtract(pivotPosition);
+      const length = delta.magnitude();
+      const midpoint = pivotPosition.add(body.position).multiply(0.5);
+      const angle = -Math.atan2(delta.x, -delta.y);
 
-    positionComponent.world.x = midpoint.x;
-    positionComponent.world.y = midpoint.y;
-    positionComponent.local.x = midpoint.x;
-    positionComponent.local.y = midpoint.y;
+      positionComponent.world.x = midpoint.x;
+      positionComponent.world.y = midpoint.y;
+      positionComponent.local.x = midpoint.x;
+      positionComponent.local.y = midpoint.y;
 
-    rotationComponent.world = angle;
-    rotationComponent.local = angle;
+      rotationComponent.world = angle;
+      rotationComponent.local = angle;
 
-    spriteComponent.width = armWidth;
-    spriteComponent.height = length;
+      spriteComponent.width = armWidth;
+      spriteComponent.height = length;
+    }
   },
 });

--- a/documentation-site/src/pages/demos/nine-slice/_panel.system.ts
+++ b/documentation-site/src/pages/demos/nine-slice/_panel.system.ts
@@ -25,15 +25,18 @@ export const createPanelEcsSystem = (
   time: Time,
 ): EcsSystem<[SpriteEcsComponent, PanelEcsComponent]> => ({
   query: [spriteId, panelId],
-  run: (result) => {
-    const [sprite, panel] = result.components;
-    const { minSize, maxSize } = panel;
+  update: (_world, { components: [sprites, panels] }) => {
+    for (let i = 0; i < sprites.length; i++) {
+      const sprite = sprites[i];
+      const panel = panels[i];
+      const { minSize, maxSize } = panel;
 
-    const phase =
-      (Math.sin((time.timeInSeconds * Math.PI * 2) / cycleSeconds) + 1) / 2;
-    const size = lerp(minSize, maxSize, phase);
+      const phase =
+        (Math.sin((time.timeInSeconds * Math.PI * 2) / cycleSeconds) + 1) / 2;
+      const size = lerp(minSize, maxSize, phase);
 
-    sprite.width = size;
-    // sprite.height = size;
+      sprite.width = size;
+      // sprite.height = size;
+    }
   },
 });

--- a/documentation-site/src/pages/demos/particles/_ambient-emitter.system.ts
+++ b/documentation-site/src/pages/demos/particles/_ambient-emitter.system.ts
@@ -17,11 +17,11 @@ export const createAmbientEmitterEcsSystem = (): EcsSystem<
 > => ({
   query: [ParticleEmitterId],
   tags: [ambientEmitterId],
-  run: (result) => {
-    const [particleEmitterComponent] = result.components;
-
-    for (const emitter of particleEmitterComponent.emitters.values()) {
-      emitter.emitIfNotEmitting();
+  update: (_world, { components: [particleEmitterComponents] }) => {
+    for (const particleEmitterComponent of particleEmitterComponents) {
+      for (const emitter of particleEmitterComponent.emitters.values()) {
+        emitter.emitIfNotEmitting();
+      }
     }
   },
 });

--- a/documentation-site/src/pages/demos/prismatic-joint/_pump.system.ts
+++ b/documentation-site/src/pages/demos/prismatic-joint/_pump.system.ts
@@ -7,24 +7,24 @@ export const createPumpEcsSystem = (
   time: Time,
 ): EcsSystem<[PumpEcsComponent]> => ({
   query: [pumpId],
-  run: (result) => {
-    const [pump] = result.components;
+  update: (_world, { components: [pumps] }) => {
+    for (const pump of pumps) {
+      pump.elapsedSeconds += time.deltaTimeInSeconds;
 
-    pump.elapsedSeconds += time.deltaTimeInSeconds;
+      if (pump.elapsedSeconds < pump.intervalSeconds) {
+        continue;
+      }
 
-    if (pump.elapsedSeconds < pump.intervalSeconds) {
-      return;
-    }
+      pump.elapsedSeconds = 0;
 
-    pump.elapsedSeconds = 0;
+      const impulse: Vector2 =
+        pump.direction === 1 ? pump.impulse : pump.impulse.negate();
 
-    const impulse: Vector2 =
-      pump.direction === 1 ? pump.impulse : pump.impulse.negate();
+      pump.joint.bodyB.applyImpulse(impulse, Vector2.zero);
 
-    pump.joint.bodyB.applyImpulse(impulse, Vector2.zero);
-
-    if (pump.alternate) {
-      pump.direction = pump.direction === 1 ? -1 : 1;
+      if (pump.alternate) {
+        pump.direction = pump.direction === 1 ? -1 : 1;
+      }
     }
   },
 });

--- a/documentation-site/src/pages/demos/revolute-joint/_push.system.ts
+++ b/documentation-site/src/pages/demos/revolute-joint/_push.system.ts
@@ -6,19 +6,19 @@ export const createPushEcsSystem = (
   time: Time,
 ): EcsSystem<[PushEcsComponent]> => ({
   query: [pushId],
-  run: (result) => {
-    const [push] = result.components;
+  update: (_world, { components: [pushes] }) => {
+    for (const push of pushes) {
+      push.elapsedSeconds += time.deltaTimeInSeconds;
 
-    push.elapsedSeconds += time.deltaTimeInSeconds;
+      if (push.elapsedSeconds < push.intervalSeconds) {
+        continue;
+      }
 
-    if (push.elapsedSeconds < push.intervalSeconds) {
-      return;
+      push.elapsedSeconds = 0;
+
+      const worldContactPoint = push.localContactPoint.rotate(push.body.angle);
+
+      push.body.applyImpulse(push.impulse, worldContactPoint);
     }
-
-    push.elapsedSeconds = 0;
-
-    const worldContactPoint = push.localContactPoint.rotate(push.body.angle);
-
-    push.body.applyImpulse(push.impulse, worldContactPoint);
   },
 });

--- a/documentation-site/src/pages/demos/rolling-ball/_camera-follow.system.ts
+++ b/documentation-site/src/pages/demos/rolling-ball/_camera-follow.system.ts
@@ -30,15 +30,16 @@ export const createCameraFollowEcsSystem = (
   time: Time,
 ): EcsSystem<[CameraEcsComponent, PositionEcsComponent]> => ({
   query: [cameraId, positionId],
-  run: (result) => {
-    const [, cameraPosition] = result.components;
-    const t = 1 - Math.exp(-followSpeed * time.deltaTimeInSeconds);
+  update: (_world, { components: [, cameraPositions] }) => {
+    for (const cameraPosition of cameraPositions) {
+      const t = 1 - Math.exp(-followSpeed * time.deltaTimeInSeconds);
 
-    cameraPosition.world.x +=
-      (targetPosition.world.x - cameraPosition.world.x) * t;
-    cameraPosition.world.y +=
-      (targetPosition.world.y - cameraPosition.world.y) * t;
-    cameraPosition.local.x = cameraPosition.world.x;
-    cameraPosition.local.y = cameraPosition.world.y;
+      cameraPosition.world.x +=
+        (targetPosition.world.x - cameraPosition.world.x) * t;
+      cameraPosition.world.y +=
+        (targetPosition.world.y - cameraPosition.world.y) * t;
+      cameraPosition.local.x = cameraPosition.world.x;
+      cameraPosition.local.y = cameraPosition.world.y;
+    }
   },
 });

--- a/documentation-site/src/pages/demos/rolling-ball/_jump.system.ts
+++ b/documentation-site/src/pages/demos/rolling-ball/_jump.system.ts
@@ -38,9 +38,9 @@ function involvesBoth(
  * impulse when `jumpInput` triggers while grounded, and resets the ball back
  * to `spawnPosition` if it ever falls `respawnFallDistance` below it (for
  * example off the end of the terrain). All the work happens once per tick in
- * `beforeQuery`, rather than per matched entity, the same way
- * `createPhysicsSyncEcsSystem` steps `physicsWorld` once in its own
- * `beforeQuery`.
+ * `update`, since `update` is already a single batched call rather than one
+ * invoked per matched entity, the same way `createPhysicsSyncEcsSystem` steps
+ * `physicsWorld` once in its own `update`.
  *
  * Must run after `createPhysicsSyncEcsSystem`, so this tick's collision
  * events are available before this system checks them.
@@ -61,7 +61,7 @@ export const createJumpEcsSystem = (
 
   return {
     query: [PhysicsBodyId],
-    beforeQuery: () => {
+    update: () => {
       if (
         physicsWorld.collisionStarts.some((pair) =>
           involvesBoth(pair, playerBody, terrainBody),
@@ -91,12 +91,6 @@ export const createJumpEcsSystem = (
         playerBody.angularVelocity = 0;
         isGrounded = false;
       }
-
-      return null;
-    },
-    run: () => {
-      // All the work happens once per tick in `beforeQuery` above; nothing
-      // needed per matched entity.
     },
   };
 };

--- a/documentation-site/src/pages/demos/rolling-ball/_roll.system.ts
+++ b/documentation-site/src/pages/demos/rolling-ball/_roll.system.ts
@@ -25,13 +25,13 @@ export const createRollEcsSystem = (
   rollInput: Axis1dAction,
 ): EcsSystem<[AngularVelocityMotorEcsComponent]> => ({
   query: [AngularVelocityMotorId],
-  run: (result) => {
-    const [motorComponent] = result.components;
-
-    // A positive angular velocity here spins the ball counter-clockwise on
-    // screen, which rolls it to the left - the opposite of a positive
-    // `rollInput.value` (the D / right-arrow side of the binding), so the
-    // sign is flipped to make D/right-arrow roll right.
-    motorComponent.targetVelocity = -rollInput.value * maxRollSpeed;
+  update: (_world, { components: [motorComponents] }) => {
+    for (const motorComponent of motorComponents) {
+      // A positive angular velocity here spins the ball counter-clockwise on
+      // screen, which rolls it to the left - the opposite of a positive
+      // `rollInput.value` (the D / right-arrow side of the binding), so the
+      // sign is flipped to make D/right-arrow roll right.
+      motorComponent.targetVelocity = -rollInput.value * maxRollSpeed;
+    }
   },
 });

--- a/documentation-site/src/pages/demos/space-shooter/_asteroid-spawner.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_asteroid-spawner.system.ts
@@ -25,59 +25,62 @@ export const createAsteroidSpawnerEcsSystem = (
   random: Random,
 ): EcsSystem<[AsteroidSpawnerEcsComponent]> => ({
   query: [asteroidSpawnerId],
-  run: (result, world) => {
-    const [spawnerComponent] = result.components;
+  update: (world, { components: [spawnerComponents] }) => {
+    for (const spawnerComponent of spawnerComponents) {
+      if (time.timeInSeconds < spawnerComponent.nextSpawnTime) {
+        continue;
+      }
 
-    if (time.timeInSeconds < spawnerComponent.nextSpawnTime) {
-      return;
+      spawnerComponent.nextSpawnTime =
+        time.timeInSeconds + spawnerComponent.timeBetweenSpawns;
+
+      const sprite =
+        spawnerComponent.asteroidSprites[
+          random.randomInt(0, spawnerComponent.asteroidSprites.length - 1)
+        ];
+
+      const x = random.randomFloat(
+        spawnerComponent.minX,
+        spawnerComponent.maxX,
+      );
+      const rotationDirection = random.randomInt(0, 1) === 0 ? 1 : -1;
+
+      const asteroidEntity = world.createEntity();
+
+      addSpriteComponent(world, asteroidEntity, sprite);
+
+      addPositionComponent(world, asteroidEntity, {
+        local: new Vector2(x, spawnerComponent.spawnY),
+        world: new Vector2(x, spawnerComponent.spawnY),
+      });
+
+      addRotationComponent(world, asteroidEntity);
+
+      addScaleComponent(world, asteroidEntity, {
+        local: new Vector2(asteroidScale, asteroidScale),
+        world: new Vector2(asteroidScale, asteroidScale),
+      });
+
+      world.addComponent(asteroidEntity, asteroidId, {
+        speed: random.randomFloat(
+          spawnerComponent.minSpeed,
+          spawnerComponent.maxSpeed,
+        ),
+        rotationSpeed: spawnerComponent.rotationSpeed * rotationDirection,
+      });
+
+      const asteroidRadius =
+        (sprite.width * asteroidScale + sprite.height * asteroidScale) / 4;
+
+      addPhysicsBodyComponent(world, asteroidEntity, {
+        physicsBody: new RigidBody({
+          shape: new CircleShape(asteroidRadius),
+          position: new Vector2(x, spawnerComponent.spawnY),
+          isStatic: false,
+          isSensor: true,
+        }),
+        isKinematic: true,
+      });
     }
-
-    spawnerComponent.nextSpawnTime =
-      time.timeInSeconds + spawnerComponent.timeBetweenSpawns;
-
-    const sprite =
-      spawnerComponent.asteroidSprites[
-        random.randomInt(0, spawnerComponent.asteroidSprites.length - 1)
-      ];
-
-    const x = random.randomFloat(spawnerComponent.minX, spawnerComponent.maxX);
-    const rotationDirection = random.randomInt(0, 1) === 0 ? 1 : -1;
-
-    const asteroidEntity = world.createEntity();
-
-    addSpriteComponent(world, asteroidEntity, sprite);
-
-    addPositionComponent(world, asteroidEntity, {
-      local: new Vector2(x, spawnerComponent.spawnY),
-      world: new Vector2(x, spawnerComponent.spawnY),
-    });
-
-    addRotationComponent(world, asteroidEntity);
-
-    addScaleComponent(world, asteroidEntity, {
-      local: new Vector2(asteroidScale, asteroidScale),
-      world: new Vector2(asteroidScale, asteroidScale),
-    });
-
-    world.addComponent(asteroidEntity, asteroidId, {
-      speed: random.randomFloat(
-        spawnerComponent.minSpeed,
-        spawnerComponent.maxSpeed,
-      ),
-      rotationSpeed: spawnerComponent.rotationSpeed * rotationDirection,
-    });
-
-    const asteroidRadius =
-      (sprite.width * asteroidScale + sprite.height * asteroidScale) / 4;
-
-    addPhysicsBodyComponent(world, asteroidEntity, {
-      physicsBody: new RigidBody({
-        shape: new CircleShape(asteroidRadius),
-        position: new Vector2(x, spawnerComponent.spawnY),
-        isStatic: false,
-        isSensor: true,
-      }),
-      isKinematic: true,
-    });
   },
 });

--- a/documentation-site/src/pages/demos/space-shooter/_asteroid.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_asteroid.system.ts
@@ -17,18 +17,28 @@ export const createAsteroidEcsSystem = (
   [AsteroidEcsComponent, PositionEcsComponent, RotationEcsComponent]
 > => ({
   query: [asteroidId, positionId, rotationId],
-  run: (result, world) => {
-    const [asteroidComponent, positionComponent, rotationComponent] =
-      result.components;
+  update: (
+    world,
+    {
+      entities,
+      components: [asteroidComponents, positionComponents, rotationComponents],
+    },
+  ) => {
+    for (let i = 0; i < entities.length; i++) {
+      const entity = entities[i];
+      const asteroidComponent = asteroidComponents[i];
+      const positionComponent = positionComponents[i];
+      const rotationComponent = rotationComponents[i];
 
-    positionComponent.world.y -=
-      asteroidComponent.speed * time.deltaTimeInSeconds;
+      positionComponent.world.y -=
+        asteroidComponent.speed * time.deltaTimeInSeconds;
 
-    rotationComponent.world +=
-      asteroidComponent.rotationSpeed * time.deltaTimeInSeconds;
+      rotationComponent.world +=
+        asteroidComponent.rotationSpeed * time.deltaTimeInSeconds;
 
-    if (positionComponent.world.y < despawnY) {
-      world.removeEntity(result.entity);
+      if (positionComponent.world.y < despawnY) {
+        world.removeEntity(entity);
+      }
     }
   },
 });

--- a/documentation-site/src/pages/demos/space-shooter/_background.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_background.system.ts
@@ -11,12 +11,12 @@ export const createBackgroundEcsSystem = (
 ): EcsSystem<[SpriteEcsComponent]> => ({
   query: [spriteId],
   tags: [backgroundId],
-  run: (result) => {
-    const [spriteComponent] = result.components;
-
-    spriteComponent.renderable.material.setUniform(
-      'u_time',
-      time.timeInSeconds,
-    );
+  update: (_world, { components: [spriteComponents] }) => {
+    for (const spriteComponent of spriteComponents) {
+      spriteComponent.renderable.material.setUniform(
+        'u_time',
+        time.timeInSeconds,
+      );
+    }
   },
 });

--- a/documentation-site/src/pages/demos/space-shooter/_bullet.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_bullet.system.ts
@@ -10,10 +10,13 @@ export const createBulletEcsSystem = (
   time: Time,
 ): EcsSystem<[BulletEcsComponent, PositionEcsComponent]> => ({
   query: [bulletId, positionId],
-  run: (result) => {
-    const [bulletComponent, positionComponent] = result.components;
+  update: (_world, { components: [bulletComponents, positionComponents] }) => {
+    for (let i = 0; i < bulletComponents.length; i++) {
+      const bulletComponent = bulletComponents[i];
+      const positionComponent = positionComponents[i];
 
-    positionComponent.world.y +=
-      bulletComponent.speed * time.deltaTimeInSeconds;
+      positionComponent.world.y +=
+        bulletComponent.speed * time.deltaTimeInSeconds;
+    }
   },
 });

--- a/documentation-site/src/pages/demos/space-shooter/_camera-shake.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_camera-shake.system.ts
@@ -20,39 +20,42 @@ export const createCameraShakeEcsSystem = (
   random: Random,
 ): EcsSystem<[CameraShakeEcsComponent, PositionEcsComponent]> => ({
   query: [cameraShakeId, positionId],
-  run: (result) => {
-    const [shakeComponent, positionComponent] = result.components;
+  update: (_world, { components: [shakeComponents, positionComponents] }) => {
+    for (let i = 0; i < shakeComponents.length; i++) {
+      const shakeComponent = shakeComponents[i];
+      const positionComponent = positionComponents[i];
 
-    if (shakeComponent.elapsedSeconds >= shakeComponent.durationSeconds) {
-      positionComponent.world.x = positionComponent.local.x;
-      positionComponent.world.y = positionComponent.local.y;
+      if (shakeComponent.elapsedSeconds >= shakeComponent.durationSeconds) {
+        positionComponent.world.x = positionComponent.local.x;
+        positionComponent.world.y = positionComponent.local.y;
 
-      return;
+        continue;
+      }
+
+      shakeComponent.elapsedSeconds += time.deltaTimeInSeconds;
+
+      if (
+        shakeComponent.elapsedSeconds >= shakeComponent.nextOffsetChangeSeconds
+      ) {
+        const remainingFraction = Math.max(
+          0,
+          1 - shakeComponent.elapsedSeconds / shakeComponent.durationSeconds,
+        );
+        const stepIntensity = shakeComponent.intensity * remainingFraction;
+
+        shakeComponent.currentOffset.x =
+          random.randomFloat(-1, 1) * stepIntensity;
+        shakeComponent.currentOffset.y =
+          random.randomFloat(-1, 1) * stepIntensity;
+
+        shakeComponent.nextOffsetChangeSeconds =
+          shakeComponent.elapsedSeconds + offsetHoldSeconds;
+      }
+
+      positionComponent.world.x =
+        positionComponent.local.x + shakeComponent.currentOffset.x;
+      positionComponent.world.y =
+        positionComponent.local.y + shakeComponent.currentOffset.y;
     }
-
-    shakeComponent.elapsedSeconds += time.deltaTimeInSeconds;
-
-    if (
-      shakeComponent.elapsedSeconds >= shakeComponent.nextOffsetChangeSeconds
-    ) {
-      const remainingFraction = Math.max(
-        0,
-        1 - shakeComponent.elapsedSeconds / shakeComponent.durationSeconds,
-      );
-      const stepIntensity = shakeComponent.intensity * remainingFraction;
-
-      shakeComponent.currentOffset.x =
-        random.randomFloat(-1, 1) * stepIntensity;
-      shakeComponent.currentOffset.y =
-        random.randomFloat(-1, 1) * stepIntensity;
-
-      shakeComponent.nextOffsetChangeSeconds =
-        shakeComponent.elapsedSeconds + offsetHoldSeconds;
-    }
-
-    positionComponent.world.x =
-      positionComponent.local.x + shakeComponent.currentOffset.x;
-    positionComponent.world.y =
-      positionComponent.local.y + shakeComponent.currentOffset.y;
   },
 });

--- a/documentation-site/src/pages/demos/space-shooter/_collision.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_collision.system.ts
@@ -17,46 +17,52 @@ export const createAsteroidCollisionEcsSystem = (
   onPlayerDeath: () => void,
 ): EcsSystem<[AsteroidEcsComponent, PositionEcsComponent]> => ({
   query: [asteroidId, positionId],
-  run: (result, world) => {
-    const asteroidEntity = result.entity;
-    const [, positionComponent] = result.components;
+  update: (world, { entities, components: [, positionComponents] }) => {
+    for (let i = 0; i < entities.length; i++) {
+      const asteroidEntity = entities[i];
+      const positionComponent = positionComponents[i];
 
-    for (const { bodyA, bodyB } of physicsWorld.collisionStarts) {
-      const entityA = bodyA.userData;
-      const entityB = bodyB.userData;
+      for (const { bodyA, bodyB } of physicsWorld.collisionStarts) {
+        const entityA = bodyA.userData;
+        const entityB = bodyB.userData;
 
-      if (entityA !== asteroidEntity && entityB !== asteroidEntity) {
-        continue;
-      }
+        if (entityA !== asteroidEntity && entityB !== asteroidEntity) {
+          continue;
+        }
 
-      const otherEntity = entityA === asteroidEntity ? entityB : entityA;
+        const otherEntity = entityA === asteroidEntity ? entityB : entityA;
 
-      if (typeof otherEntity !== 'number') {
-        continue;
-      }
+        if (typeof otherEntity !== 'number') {
+          continue;
+        }
 
-      if (world.getComponent(otherEntity, bulletId)) {
-        explosionSpawner.spawn(
-          world,
-          positionComponent.world,
-          time.timeInSeconds,
-        );
-        world.removeEntity(asteroidEntity);
-        world.removeEntity(otherEntity);
+        if (world.getComponent(otherEntity, bulletId)) {
+          explosionSpawner.spawn(
+            world,
+            positionComponent.world,
+            time.timeInSeconds,
+          );
+          world.removeEntity(asteroidEntity);
+          world.removeEntity(otherEntity);
 
-        return;
-      }
+          // Equivalent to the old per-entity `run`'s `return`: stop checking
+          // further collisions for this asteroid. Breaking the inner loop is
+          // enough since it's the last statement in the outer loop body, so
+          // control falls through to the next entity exactly as before.
+          break;
+        }
 
-      if (world.getComponent(otherEntity, PlayerId)) {
-        explosionSpawner.spawn(
-          world,
-          positionComponent.world,
-          time.timeInSeconds,
-        );
-        world.removeEntity(otherEntity);
-        onPlayerDeath();
+        if (world.getComponent(otherEntity, PlayerId)) {
+          explosionSpawner.spawn(
+            world,
+            positionComponent.world,
+            time.timeInSeconds,
+          );
+          world.removeEntity(otherEntity);
+          onPlayerDeath();
 
-        return;
+          break;
+        }
       }
     }
   },

--- a/documentation-site/src/pages/demos/space-shooter/_game-over.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_game-over.system.ts
@@ -9,39 +9,37 @@ export const createGameOverEcsSystem = (
   respawnPlayer: () => void,
 ): EcsSystem<[GameOverEcsComponent]> => ({
   query: [gameOverId],
-  run: (result, world) => {
-    const [gameOverComponent] = result.components;
+  update: (world, { components: [gameOverComponents] }) => {
+    for (const gameOverComponent of gameOverComponents) {
+      if (gameOverComponent.isGameOver && restartInput.isTriggered) {
+        gameOverComponent.isGameOver = false;
 
-    if (gameOverComponent.isGameOver && restartInput.isTriggered) {
-      gameOverComponent.isGameOver = false;
+        for (const entity of world.query([asteroidId]).entities) {
+          world.removeEntity(entity);
+        }
 
-      const entitiesToRemove: number[] = [];
+        for (const entity of world.query([bulletId]).entities) {
+          world.removeEntity(entity);
+        }
 
-      world.queryEntities([asteroidId], entitiesToRemove);
-
-      for (const entity of entitiesToRemove) {
-        world.removeEntity(entity);
+        respawnPlayer();
       }
 
-      world.queryEntities([bulletId], entitiesToRemove);
-
-      for (const entity of entitiesToRemove) {
-        world.removeEntity(entity);
-      }
-
-      respawnPlayer();
+      // Read after the restart branch (rather than at the top of the loop),
+      // so the message reflects this frame's *resolved* state instead of
+      // flashing visible for one frame on the exact tick a restart is
+      // processed.
+      gameOverComponent.messageElement.style.display =
+        gameOverComponent.isGameOver ? 'flex' : 'none';
     }
-
-    // Read after the restart branch (rather than at the top of `run`), so
-    // the message reflects this frame's *resolved* state instead of
-    // flashing visible for one frame on the exact tick a restart is
-    // processed.
-    gameOverComponent.messageElement.style.display =
-      gameOverComponent.isGameOver ? 'flex' : 'none';
   },
-  cleanupEntities: (result) => {
-    const [gameOverComponent] = result.components;
+  cleanup: (world) => {
+    const {
+      components: [gameOverComponents],
+    } = world.query<[GameOverEcsComponent]>([gameOverId]);
 
-    gameOverComponent.messageElement.remove();
+    for (const gameOverComponent of gameOverComponents) {
+      gameOverComponent.messageElement.remove();
+    }
   },
 });

--- a/documentation-site/src/pages/demos/space-shooter/_gun.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_gun.system.ts
@@ -40,34 +40,37 @@ export const createGunEcsSystem = (
 
   return {
     query: [gunId, positionId],
-    run: (result) => {
-      const [gunComponent, positionComponent] = result.components;
+    update: (_world, { components: [gunComponents, positionComponents] }) => {
+      for (let i = 0; i < gunComponents.length; i++) {
+        const gunComponent = gunComponents[i];
+        const positionComponent = positionComponents[i];
 
-      if (!shootAction.isHeld) {
-        return;
+        if (!shootAction.isHeld) {
+          continue;
+        }
+
+        if (gunComponent.nextAllowedShotTime > time.timeInSeconds) {
+          continue;
+        }
+
+        createBulletWithOffset(
+          world,
+          gunComponent,
+          positionComponent,
+          new Vector2(20, 20),
+          sound,
+        );
+        createBulletWithOffset(
+          world,
+          gunComponent,
+          positionComponent,
+          new Vector2(-20, 20),
+          sound,
+        );
+
+        gunComponent.nextAllowedShotTime =
+          time.timeInSeconds + gunComponent.timeBetweenShots;
       }
-
-      if (gunComponent.nextAllowedShotTime > time.timeInSeconds) {
-        return;
-      }
-
-      createBulletWithOffset(
-        world,
-        gunComponent,
-        positionComponent,
-        new Vector2(20, 20),
-        sound,
-      );
-      createBulletWithOffset(
-        world,
-        gunComponent,
-        positionComponent,
-        new Vector2(-20, 20),
-        sound,
-      );
-
-      gunComponent.nextAllowedShotTime =
-        time.timeInSeconds + gunComponent.timeBetweenShots;
     },
   };
 };

--- a/documentation-site/src/pages/demos/space-shooter/_movement.system.ts
+++ b/documentation-site/src/pages/demos/space-shooter/_movement.system.ts
@@ -13,25 +13,28 @@ export const createMovementEcsSystem = (
   time: Time,
 ): EcsSystem<[PlayerEcsComponent, PositionEcsComponent]> => ({
   query: [PlayerId, positionId],
-  run: (result) => {
-    const [playerComponent, positionComponent] = result.components;
+  update: (_world, { components: [playerComponents, positionComponents] }) => {
+    for (let i = 0; i < playerComponents.length; i++) {
+      const playerComponent = playerComponents[i];
+      const positionComponent = positionComponents[i];
 
-    const { speed, minX, maxX, minY, maxY } = playerComponent;
+      const { speed, minX, maxX, minY, maxY } = playerComponent;
 
-    const movementVector = moveAction.value
-      .multiply(speed * 10)
-      .multiply(time.deltaTimeInSeconds);
+      const movementVector = moveAction.value
+        .multiply(speed * 10)
+        .multiply(time.deltaTimeInSeconds);
 
-    positionComponent.world.x = clamp(
-      positionComponent.world.x + movementVector.x,
-      minX,
-      maxX,
-    );
+      positionComponent.world.x = clamp(
+        positionComponent.world.x + movementVector.x,
+        minX,
+        maxX,
+      );
 
-    positionComponent.world.y = clamp(
-      positionComponent.world.y + movementVector.y,
-      minY,
-      maxY,
-    );
+      positionComponent.world.y = clamp(
+        positionComponent.world.y + movementVector.y,
+        minY,
+        maxY,
+      );
+    }
   },
 });

--- a/documentation-site/src/pages/demos/stress-test/_fps-monitor.system.ts
+++ b/documentation-site/src/pages/demos/stress-test/_fps-monitor.system.ts
@@ -26,38 +26,38 @@ export const createFpsMonitorEcsSystem = (
 
   return {
     query: [spriteSpawnerId],
-    run: (result) => {
-      const [spawner] = result.components;
+    update: (_world, { components: [spawners] }) => {
+      for (const spawner of spawners) {
+        if (nextThresholdIndex >= fpsThresholds.length) {
+          continue;
+        }
 
-      if (nextThresholdIndex >= fpsThresholds.length) {
-        return;
-      }
+        startTimeInMilliseconds ??= time.rawTimeInMilliseconds;
 
-      startTimeInMilliseconds ??= time.rawTimeInMilliseconds;
+        // `time.fps` is a count of frames over the last second, so it only
+        // becomes meaningful once a full second of frames has been sampled.
+        // `time.timeInSeconds` can't be used for this: `Game.run` seeds it
+        // with `performance.now()`, so it can already be well past 1 second
+        // on the very first frame.
+        if (time.rawTimeInMilliseconds - startTimeInMilliseconds < 1000) {
+          continue;
+        }
 
-      // `time.fps` is a count of frames over the last second, so it only
-      // becomes meaningful once a full second of frames has been sampled.
-      // `time.timeInSeconds` can't be used for this: `Game.run` seeds it
-      // with `performance.now()`, so it can already be well past 1 second
-      // on the very first frame.
-      if (time.rawTimeInMilliseconds - startTimeInMilliseconds < 1000) {
-        return;
-      }
+        const threshold = fpsThresholds[nextThresholdIndex];
 
-      const threshold = fpsThresholds[nextThresholdIndex];
+        if (time.fps >= threshold) {
+          continue;
+        }
 
-      if (time.fps >= threshold) {
-        return;
-      }
+        console.log(
+          `FPS dropped below ${threshold}: ${spawner.spawnedCount} sprites were on screen.`,
+        );
 
-      console.log(
-        `FPS dropped below ${threshold}: ${spawner.spawnedCount} sprites were on screen.`,
-      );
+        nextThresholdIndex += 1;
 
-      nextThresholdIndex += 1;
-
-      if (nextThresholdIndex >= fpsThresholds.length) {
-        spawner.isSpawning = false;
+        if (nextThresholdIndex >= fpsThresholds.length) {
+          spawner.isSpawning = false;
+        }
       }
     },
   };

--- a/documentation-site/src/pages/demos/stress-test/_sprite-spawner.system.ts
+++ b/documentation-site/src/pages/demos/stress-test/_sprite-spawner.system.ts
@@ -23,38 +23,38 @@ export const createSpriteSpawnerEcsSystem = (
   random: Random,
 ): EcsSystem<[SpriteSpawnerEcsComponent]> => ({
   query: [spriteSpawnerId],
-  run: (result, world) => {
-    const [spawner] = result.components;
+  update: (world, { components: [spawners] }) => {
+    for (const spawner of spawners) {
+      if (!spawner.isSpawning || time.timeInSeconds < spawner.nextSpawnTime) {
+        continue;
+      }
 
-    if (!spawner.isSpawning || time.timeInSeconds < spawner.nextSpawnTime) {
-      return;
-    }
+      spawner.nextSpawnTime = time.timeInSeconds + spawner.timeBetweenBatches;
 
-    spawner.nextSpawnTime = time.timeInSeconds + spawner.timeBetweenBatches;
+      for (let i = 0; i < spawner.batchSize; i++) {
+        const position = new Vector2(
+          random.randomFloat(spawner.minX, spawner.maxX),
+          random.randomFloat(spawner.minY, spawner.maxY),
+        );
 
-    for (let i = 0; i < spawner.batchSize; i++) {
-      const position = new Vector2(
-        random.randomFloat(spawner.minX, spawner.maxX),
-        random.randomFloat(spawner.minY, spawner.maxY),
-      );
+        const entity = world.createEntity();
 
-      const entity = world.createEntity();
+        addPositionComponent(world, entity, {
+          local: position.clone(),
+          world: position.clone(),
+        });
 
-      addPositionComponent(world, entity, {
-        local: position.clone(),
-        world: position.clone(),
-      });
+        addRotationComponent(world, entity);
 
-      addRotationComponent(world, entity);
+        addScaleComponent(world, entity, {
+          local: new Vector2(spawner.spriteScale, spawner.spriteScale),
+          world: new Vector2(spawner.spriteScale, spawner.spriteScale),
+        });
 
-      addScaleComponent(world, entity, {
-        local: new Vector2(spawner.spriteScale, spawner.spriteScale),
-        world: new Vector2(spawner.spriteScale, spawner.spriteScale),
-      });
+        addSpriteComponent(world, entity, spawner.sprite);
 
-      addSpriteComponent(world, entity, spawner.sprite);
-
-      spawner.spawnedCount += 1;
+        spawner.spawnedCount += 1;
+      }
     }
   },
 });

--- a/documentation-site/src/pages/demos/torque/_gust.system.ts
+++ b/documentation-site/src/pages/demos/torque/_gust.system.ts
@@ -10,20 +10,23 @@ export const createGustEcsSystem = (
   time: Time,
 ): EcsSystem<[GustEcsComponent, PhysicsBodyEcsComponent]> => ({
   query: [gustId, PhysicsBodyId],
-  run: (result) => {
-    const [gustComponent, physicsBodyComponent] = result.components;
+  update: (_world, { components: [gustComponents, physicsBodyComponents] }) => {
+    for (let i = 0; i < gustComponents.length; i++) {
+      const gustComponent = gustComponents[i];
+      const physicsBodyComponent = physicsBodyComponents[i];
 
-    gustComponent.elapsedSeconds += time.deltaTimeInSeconds;
+      gustComponent.elapsedSeconds += time.deltaTimeInSeconds;
 
-    if (gustComponent.elapsedSeconds < gustComponent.intervalSeconds) {
-      return;
+      if (gustComponent.elapsedSeconds < gustComponent.intervalSeconds) {
+        continue;
+      }
+
+      gustComponent.elapsedSeconds = 0;
+
+      physicsBodyComponent.physicsBody.angularVelocity +=
+        gustComponent.strength * gustComponent.nextSign;
+
+      gustComponent.nextSign *= -1;
     }
-
-    gustComponent.elapsedSeconds = 0;
-
-    physicsBodyComponent.physicsBody.angularVelocity +=
-      gustComponent.strength * gustComponent.nextSign;
-
-    gustComponent.nextSign *= -1;
   },
 });

--- a/documentation-site/src/pages/demos/torque/_thruster.system.ts
+++ b/documentation-site/src/pages/demos/torque/_thruster.system.ts
@@ -18,16 +18,22 @@ export const createThrusterEcsSystem = (
   time: Time,
 ): EcsSystem<[ThrusterEcsComponent, PhysicsBodyEcsComponent]> => ({
   query: [thrusterId, PhysicsBodyId],
-  run: (result) => {
-    const [thrusterComponent, physicsBodyComponent] = result.components;
+  update: (
+    _world,
+    { components: [thrusterComponents, physicsBodyComponents] },
+  ) => {
+    for (let i = 0; i < thrusterComponents.length; i++) {
+      const thrusterComponent = thrusterComponents[i];
+      const physicsBodyComponent = physicsBodyComponents[i];
 
-    if (!thrusterComponent.holdAction.isHeld) {
-      return;
+      if (!thrusterComponent.holdAction.isHeld) {
+        continue;
+      }
+
+      physicsBodyComponent.physicsBody.applyTorque(
+        thrusterComponent.torque,
+        time.deltaTimeInSeconds,
+      );
     }
-
-    physicsBodyComponent.physicsBody.applyTorque(
-      thrusterComponent.torque,
-      time.deltaTimeInSeconds,
-    );
   },
 });

--- a/documentation-site/src/pages/demos/wrecking-ball/_arm.system.ts
+++ b/documentation-site/src/pages/demos/wrecking-ball/_arm.system.ts
@@ -36,25 +36,29 @@ export const createArmEcsSystem = (): EcsSystem<
   ]
 > => ({
   query: [armId, positionId, rotationId, spriteId],
-  run: (result) => {
-    const [arm, positionComponent, rotationComponent, spriteComponent] =
-      result.components;
-    const { pivotPosition, body, armWidth } = arm;
+  update: (_world, { components: [arms, positions, rotations, sprites] }) => {
+    for (let i = 0; i < arms.length; i++) {
+      const arm = arms[i];
+      const positionComponent = positions[i];
+      const rotationComponent = rotations[i];
+      const spriteComponent = sprites[i];
+      const { pivotPosition, body, armWidth } = arm;
 
-    const delta = body.position.subtract(pivotPosition);
-    const length = delta.magnitude();
-    const midpoint = pivotPosition.add(body.position).multiply(0.5);
-    const angle = -Math.atan2(delta.x, -delta.y);
+      const delta = body.position.subtract(pivotPosition);
+      const length = delta.magnitude();
+      const midpoint = pivotPosition.add(body.position).multiply(0.5);
+      const angle = -Math.atan2(delta.x, -delta.y);
 
-    positionComponent.world.x = midpoint.x;
-    positionComponent.world.y = midpoint.y;
-    positionComponent.local.x = midpoint.x;
-    positionComponent.local.y = midpoint.y;
+      positionComponent.world.x = midpoint.x;
+      positionComponent.world.y = midpoint.y;
+      positionComponent.local.x = midpoint.x;
+      positionComponent.local.y = midpoint.y;
 
-    rotationComponent.world = angle;
-    rotationComponent.local = angle;
+      rotationComponent.world = angle;
+      rotationComponent.local = angle;
 
-    spriteComponent.width = armWidth;
-    spriteComponent.height = length;
+      spriteComponent.width = armWidth;
+      spriteComponent.height = length;
+    }
   },
 });

--- a/e2e/fixtures/scenes/gamepad-input.ts
+++ b/e2e/fixtures/scenes/gamepad-input.ts
@@ -175,7 +175,7 @@ export const createScene: CreateScene = async (
     }),
   );
 
-  const cameraEntity = createCamera(world, {
+  createCamera(world, {
     isStatic: true,
     clearColor: toColor(inputSceneColors.clear),
     // 1 world unit == 1 screen pixel, see camera-pan-zoom.ts's identical use.
@@ -227,10 +227,11 @@ export const createScene: CreateScene = async (
     toColor(inputSceneColors.cyan),
   );
 
-  // A single system, anchored on the camera entity (query: [positionId]
-  // matches it too) so it runs exactly once per tick regardless of how many
-  // squares exist. Registered at the default `normal` priority, it runs
-  // after `registerInputs`'s early input-update system - which polls
+  // `update` is a single batched call per tick regardless of how many
+  // entities match `query`, so this system's body runs exactly once per
+  // tick without needing to anchor itself on a particular entity.
+  // Registered at the default `normal` priority, it runs after
+  // `registerInputs`'s early input-update system - which polls
   // `GamepadInputSource.update()` - and before its late reset-inputs
   // system, the same ordering `createCameraEcsSystem` relies on for
   // pan/zoom input.
@@ -243,11 +244,7 @@ export const createScene: CreateScene = async (
   // once group-gated (see `menuStickAction`), instead of drifting.
   const inputConsumerSystem: EcsSystem<[PositionEcsComponent]> = {
     query: [positionId],
-    run: (result) => {
-      if (result.entity !== cameraEntity) {
-        return;
-      }
-
+    update: () => {
       stick.position.local.x =
         stickBase.x + stickAction.value * stickRangeInWorldUnits;
       broken.position.local.x =

--- a/e2e/fixtures/scenes/keyboard-input.ts
+++ b/e2e/fixtures/scenes/keyboard-input.ts
@@ -158,7 +158,7 @@ export const createScene: CreateScene = async (
     new KeyboardHoldBinding(crouchAction, keyCodes.c),
   );
 
-  const cameraEntity = createCamera(world, {
+  createCamera(world, {
     isStatic: true,
     clearColor: toColor(inputSceneColors.clear),
     // 1 world unit == 1 screen pixel, see camera-pan-zoom.ts's identical use.
@@ -201,20 +201,17 @@ export const createScene: CreateScene = async (
   let gameTriggerCount = 0;
   let menuTriggerCount = 0;
 
-  // A single system, anchored on the camera entity (query: [positionId]
-  // matches it too) so it runs exactly once per tick regardless of how many
-  // squares exist. Registered at the default `normal` priority, it runs
-  // after `registerInputs`'s early input-update system (so this frame's
+  // `update` is a single batched call per tick regardless of how many
+  // entities match `query`, so this system's body runs exactly once per
+  // tick without needing to anchor itself on a particular entity.
+  // Registered at the default `normal` priority, it runs after
+  // `registerInputs`'s early input-update system (so this frame's
   // key events have already been dispatched) and before its late
   // reset-inputs system (so `isTriggered`/axis values are still valid) -
   // the same ordering `createCameraEcsSystem` relies on for pan/zoom input.
   const inputConsumerSystem: EcsSystem<[PositionEcsComponent]> = {
     query: [positionId],
-    run: (result) => {
-      if (result.entity !== cameraEntity) {
-        return;
-      }
-
+    update: () => {
       const deltaSeconds = time.deltaTimeInMilliseconds / 1000;
 
       mover.position.local.x +=

--- a/e2e/fixtures/scenes/mouse-input.ts
+++ b/e2e/fixtures/scenes/mouse-input.ts
@@ -156,7 +156,7 @@ export const createScene: CreateScene = async (
     new MouseHoldBinding(aimAction, mouseButtons.right),
   );
 
-  const cameraEntity = createCamera(world, {
+  createCamera(world, {
     isStatic: true,
     clearColor: toColor(inputSceneColors.clear),
     // 1 world unit == 1 screen pixel, see camera-pan-zoom.ts's identical use.
@@ -204,20 +204,17 @@ export const createScene: CreateScene = async (
   let gameTriggerCount = 0;
   let menuTriggerCount = 0;
 
-  // A single system, anchored on the camera entity (query: [positionId]
-  // matches it too) so it runs exactly once per tick regardless of how many
-  // squares exist. Registered at the default `normal` priority, it runs
-  // after `registerInputs`'s early input-update system (so this frame's
+  // `update` is a single batched call per tick regardless of how many
+  // entities match `query`, so this system's body runs exactly once per
+  // tick without needing to anchor itself on a particular entity.
+  // Registered at the default `normal` priority, it runs after
+  // `registerInputs`'s early input-update system (so this frame's
   // mouse events have already been dispatched) and before its late
   // reset-inputs system (so `isTriggered`/axis values are still valid) -
   // the same ordering `createCameraEcsSystem` relies on for pan/zoom input.
   const inputConsumerSystem: EcsSystem<[PositionEcsComponent]> = {
     query: [positionId],
-    run: (result) => {
-      if (result.entity !== cameraEntity) {
-        return;
-      }
-
+    update: () => {
       // A direct position mapping (not an accumulation) - `pointerAction`
       // represents the cursor's *current* ratio offset from center, so the
       // square should track it continuously, the same way a real cursor or

--- a/src/animations/systems/animation-system.ts
+++ b/src/animations/systems/animation-system.ts
@@ -76,26 +76,26 @@ export const createAnimationEcsSystem = (
   time: Time,
 ): EcsSystem<[AnimationEcsComponent]> => ({
   query: [animationId],
-  run: (result) => {
-    const [animationComponent] = result.components;
+  update: (_world, { components: [animationComponents] }) => {
+    for (const animationComponent of animationComponents) {
+      if (animationComponent.animations.length === 0) {
+        continue;
+      }
 
-    if (animationComponent.animations.length === 0) {
-      return;
-    }
+      // Iterate backwards so we can safely remove animations
+      for (let i = animationComponent.animations.length - 1; i >= 0; i--) {
+        const animation = animationComponent.animations[i];
+        const animationComplete = updateAnimation(animation, time);
 
-    // Iterate backwards so we can safely remove animations
-    for (let i = animationComponent.animations.length - 1; i >= 0; i--) {
-      const animation = animationComponent.animations[i];
-      const animationComplete = updateAnimation(animation, time);
+        if (animationComplete) {
+          animation.updateCallback(animation.endValue);
 
-      if (animationComplete) {
-        animation.updateCallback(animation.endValue);
+          const shouldRemove = !handleLooping(animation);
 
-        const shouldRemove = !handleLooping(animation);
-
-        if (shouldRemove) {
-          animation.finishedCallback?.();
-          animationComponent.animations.splice(i, 1);
+          if (shouldRemove) {
+            animation.finishedCallback?.();
+            animationComponent.animations.splice(i, 1);
+          }
         }
       }
     }

--- a/src/animations/systems/sprite-animation-system.ts
+++ b/src/animations/systems/sprite-animation-system.ts
@@ -19,51 +19,58 @@ export const createSpriteAnimationEcsSystem = (
   animationRegistry: AssetRegistry<AnimationClip>,
 ): EcsSystem<[SpriteAnimationEcsComponent, SpriteEcsComponent]> => ({
   query: [spriteAnimationId, spriteId],
-  run: (result) => {
-    const [spriteAnimationComponent, spriteComponent] = result.components;
+  update: (
+    _world,
+    { components: [spriteAnimationComponents, spriteComponents] },
+  ) => {
+    for (let i = 0; i < spriteAnimationComponents.length; i++) {
+      const spriteAnimationComponent = spriteAnimationComponents[i];
+      const spriteComponent = spriteComponents[i];
 
-    const secondsElapsedSinceLastFrameChange =
-      time.timeInSeconds -
-      spriteAnimationComponent.lastFrameChangeTimeInSeconds;
+      const secondsElapsedSinceLastFrameChange =
+        time.timeInSeconds -
+        spriteAnimationComponent.lastFrameChangeTimeInSeconds;
 
-    const scaledFrameDurationInSeconds =
-      spriteAnimationComponent.frameDurationMilliseconds /
-      1000 /
-      spriteAnimationComponent.playbackSpeed;
+      const scaledFrameDurationInSeconds =
+        spriteAnimationComponent.frameDurationMilliseconds /
+        1000 /
+        spriteAnimationComponent.playbackSpeed;
 
-    if (scaledFrameDurationInSeconds <= 0) {
-      throw new Error(
-        `Invalid frame duration: ${spriteAnimationComponent.frameDurationMilliseconds} ms. Frame duration must be greater than 0.`,
+      if (scaledFrameDurationInSeconds <= 0) {
+        throw new Error(
+          `Invalid frame duration: ${spriteAnimationComponent.frameDurationMilliseconds} ms. Frame duration must be greater than 0.`,
+        );
+      }
+
+      const frameHasFinished =
+        secondsElapsedSinceLastFrameChange >= scaledFrameDurationInSeconds;
+
+      if (!frameHasFinished) {
+        continue;
+      }
+
+      const animationClip = animationRegistry.getDirect(
+        spriteAnimationComponent.animationClipHandle,
       );
+
+      const animationFrame = animationClip.getFrame(
+        spriteAnimationComponent.animationFrameIndex,
+      );
+
+      if (
+        spriteAnimationComponent.animationFrameIndex >=
+        animationClip.frameCount - 1
+      ) {
+        spriteAnimationComponent.animationFrameIndex = 0;
+      } else {
+        spriteAnimationComponent.animationFrameIndex++;
+      }
+
+      spriteComponent.uvOffset.x = animationFrame.offset.x;
+      spriteComponent.uvOffset.y = animationFrame.offset.y;
+
+      spriteAnimationComponent.lastFrameChangeTimeInSeconds =
+        time.timeInSeconds;
     }
-
-    const frameHasFinished =
-      secondsElapsedSinceLastFrameChange >= scaledFrameDurationInSeconds;
-
-    if (!frameHasFinished) {
-      return;
-    }
-
-    const animationClip = animationRegistry.getDirect(
-      spriteAnimationComponent.animationClipHandle,
-    );
-
-    const animationFrame = animationClip.getFrame(
-      spriteAnimationComponent.animationFrameIndex,
-    );
-
-    if (
-      spriteAnimationComponent.animationFrameIndex >=
-      animationClip.frameCount - 1
-    ) {
-      spriteAnimationComponent.animationFrameIndex = 0;
-    } else {
-      spriteAnimationComponent.animationFrameIndex++;
-    }
-
-    spriteComponent.uvOffset.x = animationFrame.offset.x;
-    spriteComponent.uvOffset.y = animationFrame.offset.y;
-
-    spriteAnimationComponent.lastFrameChangeTimeInSeconds = time.timeInSeconds;
   },
 });

--- a/src/audio/systems/audio-system.ts
+++ b/src/audio/systems/audio-system.ts
@@ -12,20 +12,24 @@ import { EcsSystem } from '../../ecs/ecs-system.js';
  */
 export const createAudioEcsSystem = (): EcsSystem<[AudioEcsComponent]> => ({
   query: [audioId],
-  run: (result) => {
-    const [audioComponent] = result.components;
-
-    if (audioComponent.playSound) {
-      audioComponent.sound.play();
-      audioComponent.playSound = false;
+  update: (_world, { components: [audioComponents] }) => {
+    for (const audioComponent of audioComponents) {
+      if (audioComponent.playSound) {
+        audioComponent.sound.play();
+        audioComponent.playSound = false;
+      }
     }
   },
-  cleanupEntities(queryResult) {
-    const [audioComponent] = queryResult.components;
+  cleanup(world) {
+    const {
+      components: [audioComponents],
+    } = world.query<[AudioEcsComponent]>([audioId]);
 
-    if (audioComponent.sound.playing()) {
-      audioComponent.sound.stop();
-      audioComponent.sound.unload();
+    for (const audioComponent of audioComponents) {
+      if (audioComponent.sound.playing()) {
+        audioComponent.sound.stop();
+        audioComponent.sound.unload();
+      }
     }
   },
 });

--- a/src/common/systems/age-scale-system.test.ts
+++ b/src/common/systems/age-scale-system.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { addLifetimeComponent, LifetimeEcsComponent } from '../../lifecycle';
-import { EcsWorld, QueryResult } from '../../ecs';
+import {
+  addLifetimeComponent,
+  LifetimeEcsComponent,
+} from '../../lifecycle/index.js';
+import { EcsWorld, QueryResult } from '../../ecs/index.js';
 import {
   addAgeScaleComponent,
   addScaleComponent,
   AgeScaleEcsComponent,
   ScaleEcsComponent,
-} from '../components';
-import { createAgeScaleEcsSystem } from './age-scale-system';
+} from '../components/index.js';
+import { createAgeScaleEcsSystem } from './age-scale-system.js';
 
 describe('AgeScaleSystem', () => {
   const world = new EcsWorld();
@@ -32,12 +35,12 @@ describe('AgeScaleSystem', () => {
     const queryResult: QueryResult<
       [LifetimeEcsComponent, ScaleEcsComponent, AgeScaleEcsComponent]
     > = {
-      entity,
-      components: [lifetimeComponent, scaleComponent, ageScaleComponent],
+      entities: [entity],
+      components: [[lifetimeComponent], [scaleComponent], [ageScaleComponent]],
     };
 
     // Act
-    system.run(queryResult, world, null);
+    system.update(world, queryResult);
 
     // Assert
     const expectedScaleX = 0.75; // Calculated as: 1 * (1 - 0.5) + 0.5 * 0.5
@@ -72,12 +75,12 @@ describe('AgeScaleSystem', () => {
     const queryResult: QueryResult<
       [LifetimeEcsComponent, ScaleEcsComponent, AgeScaleEcsComponent]
     > = {
-      entity,
-      components: [lifetimeComponent, scaleComponent, ageScaleComponent],
+      entities: [entity],
+      components: [[lifetimeComponent], [scaleComponent], [ageScaleComponent]],
     };
 
     // Act
-    system.run(queryResult, world, null);
+    system.update(world, queryResult);
 
     // Assert
     expect(scaleComponent.local.x).toBeCloseTo(expectedScaleX);

--- a/src/common/systems/age-scale-system.ts
+++ b/src/common/systems/age-scale-system.ts
@@ -17,19 +17,21 @@ export const createAgeScaleEcsSystem = (): EcsSystem<
   [LifetimeEcsComponent, ScaleEcsComponent, AgeScaleEcsComponent]
 > => ({
   query: [lifetimeId, scaleId, ageScaleId],
-  run: (result) => {
-    const [lifetimeComponent, scaleComponent, ageScaleComponent] =
-      result.components;
+  update: (_world, { components: [lifetimes, scales, ageScales] }) => {
+    for (let i = 0; i < lifetimes.length; i++) {
+      const lifetime = lifetimes[i];
+      const scale = scales[i];
+      const ageScale = ageScales[i];
 
-    const lifetimeRatio =
-      lifetimeComponent.elapsedSeconds / lifetimeComponent.durationSeconds;
-    const newScaleX =
-      ageScaleComponent.originalScaleX * (1 - lifetimeRatio) +
-      ageScaleComponent.finalLifetimeScaleX * lifetimeRatio;
-    const newScaleY =
-      ageScaleComponent.originalScaleY * (1 - lifetimeRatio) +
-      ageScaleComponent.finalLifetimeScaleY * lifetimeRatio;
-    scaleComponent.local.x = newScaleX;
-    scaleComponent.local.y = newScaleY;
+      const lifetimeRatio = lifetime.elapsedSeconds / lifetime.durationSeconds;
+      const invertedRatio = 1 - lifetimeRatio;
+
+      scale.local.x =
+        ageScale.originalScaleX * invertedRatio +
+        ageScale.finalLifetimeScaleX * lifetimeRatio;
+      scale.local.y =
+        ageScale.originalScaleY * invertedRatio +
+        ageScale.finalLifetimeScaleY * lifetimeRatio;
+    }
   },
 });

--- a/src/common/systems/parent-position-system.ts
+++ b/src/common/systems/parent-position-system.ts
@@ -1,8 +1,11 @@
-import { EcsSystem } from '../../ecs/ecs-system';
+import { EcsSystem } from '../../ecs/ecs-system.js';
 import { EcsWorld } from '../../ecs/ecs-world.js';
 import { PositionEcsComponent, positionId } from '../components/index.js';
-import { parentId } from '../components/parent-component';
-import { createTransformCache, resetTransformCache } from './transform-cache';
+import { parentId } from '../components/parent-component.js';
+import {
+  createTransformCache,
+  resetTransformCache,
+} from './transform-cache.js';
 
 const cache = createTransformCache();
 
@@ -71,16 +74,15 @@ function computeWorld(entity: number, world: EcsWorld): void {
   cache.computed.add(entity);
 }
 
-type TransformSystem = EcsSystem<[PositionEcsComponent], void> & {
-  beforeQuery: (world: EcsWorld) => void;
-};
-
-export const createParentPositionEcsSystem = (): TransformSystem => ({
+export const createParentPositionEcsSystem = (): EcsSystem<
+  [PositionEcsComponent]
+> => ({
   query: [positionId],
-  beforeQuery: () => resetTransformCache(cache),
-  run: (result, world) => {
-    const entity = result.entity;
+  update: (world, { entities }) => {
+    resetTransformCache(cache);
 
-    computeWorld(entity, world);
+    for (const entity of entities) {
+      computeWorld(entity, world);
+    }
   },
 });

--- a/src/common/systems/parent-rotation-system.ts
+++ b/src/common/systems/parent-rotation-system.ts
@@ -1,8 +1,11 @@
-import { EcsSystem } from '../../ecs/ecs-system';
+import { EcsSystem } from '../../ecs/ecs-system.js';
 import { EcsWorld } from '../../ecs/ecs-world.js';
 import { RotationEcsComponent, rotationId } from '../components/index.js';
-import { parentId } from '../components/parent-component';
-import { createTransformCache, resetTransformCache } from './transform-cache';
+import { parentId } from '../components/parent-component.js';
+import {
+  createTransformCache,
+  resetTransformCache,
+} from './transform-cache.js';
 
 const cache = createTransformCache();
 
@@ -65,16 +68,15 @@ function computeWorld(entity: number, world: EcsWorld): void {
   cache.computed.add(entity);
 }
 
-type TransformSystem = EcsSystem<[RotationEcsComponent], void> & {
-  beforeQuery: (world: EcsWorld) => void;
-};
-
-export const createParentRotationEcsSystem = (): TransformSystem => ({
+export const createParentRotationEcsSystem = (): EcsSystem<
+  [RotationEcsComponent]
+> => ({
   query: [rotationId],
-  beforeQuery: () => resetTransformCache(cache),
-  run: (result, world) => {
-    const entity = result.entity;
+  update: (world, { entities }) => {
+    resetTransformCache(cache);
 
-    computeWorld(entity, world);
+    for (const entity of entities) {
+      computeWorld(entity, world);
+    }
   },
 });

--- a/src/common/systems/parent-scale-system.ts
+++ b/src/common/systems/parent-scale-system.ts
@@ -1,8 +1,11 @@
-import { EcsSystem } from '../../ecs/ecs-system';
+import { EcsSystem } from '../../ecs/ecs-system.js';
 import { EcsWorld } from '../../ecs/ecs-world.js';
 import { ScaleEcsComponent, scaleId } from '../components/index.js';
-import { parentId } from '../components/parent-component';
-import { createTransformCache, resetTransformCache } from './transform-cache';
+import { parentId } from '../components/parent-component.js';
+import {
+  createTransformCache,
+  resetTransformCache,
+} from './transform-cache.js';
 
 const cache = createTransformCache();
 
@@ -69,16 +72,15 @@ function computeWorld(entity: number, world: EcsWorld): void {
   cache.computed.add(entity);
 }
 
-type TransformSystem = EcsSystem<[ScaleEcsComponent], void> & {
-  beforeQuery: (world: EcsWorld) => void;
-};
-
-export const createParentScaleEcsSystem = (): TransformSystem => ({
+export const createParentScaleEcsSystem = (): EcsSystem<
+  [ScaleEcsComponent]
+> => ({
   query: [scaleId],
-  beforeQuery: () => resetTransformCache(cache),
-  run: (result, world) => {
-    const entity = result.entity;
+  update: (world, { entities }) => {
+    resetTransformCache(cache);
 
-    computeWorld(entity, world);
+    for (const entity of entities) {
+      computeWorld(entity, world);
+    }
   },
 });

--- a/src/common/systems/transform-system.ts
+++ b/src/common/systems/transform-system.ts
@@ -1,4 +1,4 @@
-import { EcsSystem } from '../../ecs/ecs-system';
+import { EcsSystem } from '../../ecs/ecs-system.js';
 import { EcsWorld } from '../../ecs/ecs-world.js';
 import {
   PositionEcsComponent,
@@ -150,25 +150,6 @@ function computeWorld(
 }
 
 /**
- * Per-frame state for `createTransformEcsSystem`, reused across frames to
- * avoid reallocating its sets every frame.
- */
-interface TransformRunState {
-  /** Tracks entities visited/computed during the current frame. */
-  cache: TransformCache;
-
-  /**
-   * Entities whose world transform is static and has already been computed,
-   * so `computeWorld` can skip them entirely. Persists across frames.
-   */
-  frozen: Set<number>;
-}
-
-type TransformSystem = EcsSystem<[PositionEcsComponent], TransformRunState> & {
-  beforeQuery: (world: EcsWorld) => TransformRunState;
-};
-
-/**
  * Creates a system that computes the world position, rotation and scale of
  * every entity from its local transform and, if it has a `ParentEcsComponent`,
  * its parent's world transform.
@@ -178,23 +159,24 @@ type TransformSystem = EcsSystem<[PositionEcsComponent], TransformRunState> & {
  * every subsequent frame.
  * @returns The transform ECS system.
  */
-export const createTransformEcsSystem = (): TransformSystem => {
-  const state: TransformRunState = {
-    cache: createTransformCache(),
-    frozen: new Set<number>(),
-  };
+export const createTransformEcsSystem = (): EcsSystem<
+  [PositionEcsComponent]
+> => {
+  const cache = createTransformCache();
+
+  // Entities whose world transform is static and has already been computed,
+  // so `computeWorld` can skip them entirely. Persists across frames.
+  const frozen = new Set<number>();
 
   return {
     query: [positionId],
 
-    beforeQuery: () => {
-      resetTransformCache(state.cache);
+    update: (world, { entities }) => {
+      resetTransformCache(cache);
 
-      return state;
-    },
-
-    run: (result, world, { cache, frozen }) => {
-      computeWorld(result.entity, cache, frozen, world);
+      for (const entity of entities) {
+        computeWorld(entity, cache, frozen, world);
+      }
     },
   };
 };

--- a/src/ecs/ecs-system.ts
+++ b/src/ecs/ecs-system.ts
@@ -1,92 +1,55 @@
-import { KeysFromComponents, TagKey } from './ecs-component';
-import { EcsWorld, QueryResult } from './ecs-world';
+import { KeysFromComponents, TagKey } from './ecs-component.js';
+import { EcsWorld, QueryResult } from './ecs-world.js';
 
 /**
- * A unit of per-tick logic that operates on every entity matching its
- * `query` (and `tags`, if given). Register an instance with
- * `EcsWorld.addSystem` to have `run` invoked for each matching entity every
- * `EcsWorld.update` call.
+ * A unit of per-tick logic that operates on all entities matching its
+ * `query` (and `tags`, if given) in a single batch call. Register an instance
+ * with `EcsWorld.addSystem` to have `update` invoked every `EcsWorld.update` call.
+ *
  * @typeParam TQuery - The tuple of component data types the system reads,
  * in query order. Matches the array of {@link ComponentKey}s in `query`.
- * @typeParam TBeforeQueryResult - The type returned by `beforeQuery` and
- * passed to every `run` call this tick. Defaults to `null` when
- * `beforeQuery` is not implemented.
- * @typeParam TAfterRunInput - The type returned by `run` and collected into
- * the array passed to `afterRun`. Defaults to `void` when `run` returns
- * nothing.
  */
 export interface EcsSystem<
   TQuery extends readonly unknown[] = readonly unknown[],
-  TBeforeQueryResult = null,
-  TAfterRunInput = void,
 > {
   /**
-   * The component keys an entity must have for this system to process it.
-   * Order determines the order of `queryResult.components` passed to `run`.
+   * The component keys an entity must have for this system to query it.
+   * Order determines the order of arrays inside `queryResult.components`.
    */
   query: KeysFromComponents<TQuery>;
+
   /**
-   * Additional tag keys an entity must have for this system to process it.
-   * Unlike `query`, tags don't contribute a value to
-   * `queryResult.components`.
+   * Additional tag keys an entity must have for this system to query it.
+   * Unlike `query`, tags don't contribute values to `queryResult.components`.
    */
   tags?: TagKey[];
+
   /**
    * Invoked once when the system is registered with an `EcsWorld`. Use it to
-   * acquire resources the system will need for its lifetime.
+   * acquire resources or set up state the system will need for its lifetime.
+   *
    * @param world - The `EcsWorld` the system was registered with.
    */
   onRegister?(world: EcsWorld): void;
+
   /**
-   * Invoked once per tick for every entity matching `query` (and `tags`).
-   * @param queryResult - The matched entity's id and its queried
-   * component data, in query order.
+   * Invoked once per tick with all entities and components matching `query` (and `tags`).
+   * The system handles its own iteration, enabling operations across all matched entities
+   * (e.g., spatial partitioning, batching, or sorting).
+   *
    * @param world - The `EcsWorld` running this system.
-   * @param beforeQueryResult - The value returned by `beforeQuery` for this
-   * tick, or `null` if `beforeQuery` is not implemented.
-   * @returns A value to be collected, along with every other matched
-   * entity's return value this tick, into the array passed to `afterRun`.
+   * @param queryResult - The batch of matched entity IDs and their corresponding component data.
    */
-  run(
-    queryResult: QueryResult<TQuery>,
-    world: EcsWorld,
-    beforeQueryResult: TBeforeQueryResult,
-  ): TAfterRunInput;
+  update(world: EcsWorld, queryResult: QueryResult<TQuery>): void;
+
   /**
-   * Invoked once per tick, after `run` has been called for every matched
-   * entity, with an array of every one of those calls' return values (in
-   * query order; empty if nothing matched). Use it for work that needs to
-   * see the whole tick's results together rather than one entity at a time:
-   * for example the render system collects one `RenderPassResult` per
-   * camera in `run`, then `afterRun` draws every camera's batch once all of
-   * them are known.
+   * Invoked once when the system is removed from an `EcsWorld` or when the world
+   * is stopped via `EcsWorld.stop`. Use it to release resources acquired during
+   * system lifetime or execution.
+   *
+   * @param world - The `EcsWorld` releasing the system.
    */
-  afterRun?(inputs: TAfterRunInput[]): void;
-  /**
-   * Invoked once per tick, before entity iteration begins, to compute a
-   * value shared across every `run` call this tick. Use it for expensive,
-   * shared pre-computation (for example a spatial index) that would be
-   * wasteful to redo for each matched entity.
-   * @param world - The `EcsWorld` running this system.
-   * @returns The value to pass as `beforeQueryResult` to every `run` call
-   * this tick.
-   */
-  beforeQuery?(world: EcsWorld): TBeforeQueryResult;
-  /**
-   * Invoked for every entity still matching `query` (and `tags`) when the
-   * owning `EcsWorld` is stopped via `EcsWorld.stop`. Use it to release
-   * resources the system acquired for that entity.
-   * @param queryResult - The matched entity's id and its queried
-   * component data, in query order.
-   * @param world - The `EcsWorld` that is stopping.
-   */
-  cleanupEntities?(queryResult: QueryResult<TQuery>, world: EcsWorld): void;
-  /**
-   * Invoked once when the system is removed from an `EcsWorld`. Use it to
-   * release resources the system acquired for its lifetime.
-   * @param world - The `EcsWorld` the system was removed from.
-   */
-  cleanupSystem?(world: EcsWorld): void;
+  cleanup?(world: EcsWorld): void;
 }
 
 /**

--- a/src/ecs/ecs-world.test.ts
+++ b/src/ecs/ecs-world.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { EcsWorld } from './ecs-world';
-import { EcsSystem } from './ecs-system';
+import { EcsWorld } from './ecs-world.js';
+import { EcsSystem } from './ecs-system.js';
 import {
   PositionEcsComponent,
   positionId,
@@ -9,7 +9,7 @@ import {
   SpeedEcsComponent,
   speedId,
 } from '../common/index.js';
-import { createComponentId } from './ecs-component';
+import { createComponentId } from './ecs-component.js';
 import { Vector2 } from '../math/index.js';
 
 describe('EcsWorld', () => {
@@ -33,23 +33,22 @@ describe('EcsWorld', () => {
     world.addComponent(entity1, rotationId, rot1);
     world.addComponent(entity2, positionId, pos2);
 
-    const run = vi.fn();
+    const update = vi.fn();
     const system: EcsSystem<[PositionEcsComponent, RotationEcsComponent]> = {
       query: [positionId, rotationId],
-      run,
+      update,
     };
 
     world.addSystem(system);
     world.update();
 
-    expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith(
-      expect.objectContaining({
-        entity: entity1,
-        components: [pos1, rot1],
-      }),
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
       world,
-      null,
+      expect.objectContaining({
+        entities: [entity1],
+        components: [[pos1], [rot1]],
+      }),
     );
   });
 
@@ -69,11 +68,10 @@ describe('EcsWorld', () => {
     const results: Array<{ entity: number; component: { value: string } }> = [];
     const system: EcsSystem<[{ value: string }]> = {
       query: [tagId],
-      run: (result) => {
-        results.push({
-          entity: result.entity,
-          component: result.components[0],
-        });
+      update: (_world, { entities, components: [values] }) => {
+        for (let i = 0; i < entities.length; i++) {
+          results.push({ entity: entities[i], component: values[i] });
+        }
       },
     };
 
@@ -107,23 +105,22 @@ describe('EcsWorld', () => {
     world.addComponent(entity2, positionId, position2);
     world.addComponent(entity2, speedId, speed2);
 
-    const run = vi.fn();
+    const update = vi.fn();
     const system: EcsSystem<[PositionEcsComponent, SpeedEcsComponent]> = {
       query: [positionId, speedId],
-      run,
+      update,
     };
 
     world.addSystem(system);
     world.update();
 
-    expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith(
-      expect.objectContaining({
-        entity: entity2,
-        components: [position2, speed2],
-      }),
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
       world,
-      null,
+      expect.objectContaining({
+        entities: [entity2],
+        components: [[position2], [speed2]],
+      }),
     );
   });
 
@@ -134,12 +131,64 @@ describe('EcsWorld', () => {
 
     const system: EcsSystem<[TestComponent]> = {
       query: [nonexistentId],
-      run: () => {},
+      update: () => {},
     };
 
     world.addSystem(system);
 
     expect(() => world.update()).not.toThrow();
+  });
+
+  it('calls update once per tick with every matched entity and component together', () => {
+    const world = new EcsWorld();
+    const entity1 = world.createEntity();
+    const entity2 = world.createEntity();
+
+    world.addComponent(entity1, positionId, {
+      local: Vector2.zero,
+      world: Vector2.zero,
+    });
+    world.addComponent(entity2, positionId, {
+      local: Vector2.zero,
+      world: Vector2.zero,
+    });
+
+    const update = vi.fn();
+    const system: EcsSystem<[PositionEcsComponent]> = {
+      query: [positionId],
+      update,
+    };
+
+    world.addSystem(system);
+    world.update();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
+      world,
+      expect.objectContaining({ entities: [entity1, entity2] }),
+    );
+  });
+
+  it('calls update once with empty arrays when no entities match the query', () => {
+    const world = new EcsWorld();
+    const nonexistentId = createComponentId<{ test: number }>(
+      'nonexistent-update',
+    );
+
+    const update = vi.fn();
+    const system: EcsSystem<[{ test: number }]> = {
+      query: [nonexistentId],
+      update,
+    };
+
+    world.addSystem(system);
+    world.update();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
+      world,
+      expect.objectContaining({ entities: [], components: [[]] }),
+    );
   });
 
   it('runs systems with query results', () => {
@@ -160,24 +209,27 @@ describe('EcsWorld', () => {
     world.addComponent(entity1, positionId, pos1);
     world.addComponent(entity2, positionId, pos2);
 
-    const run = vi.fn(
-      (result: { entity: number; components: [PositionEcsComponent] }) => {
-        const [position] = result.components;
-
-        position.local.x += 10;
+    const update = vi.fn(
+      (
+        _world: EcsWorld,
+        { components: [positions] }: { components: [PositionEcsComponent[]] },
+      ) => {
+        for (const position of positions) {
+          position.local.x += 10;
+        }
       },
     );
 
     const system: EcsSystem<[PositionEcsComponent]> = {
       query: [positionId],
-      run,
+      update,
     };
 
     world.addSystem(system);
 
     world.update();
 
-    expect(run).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenCalledTimes(1);
     expect(pos1.local.x).toBe(5);
     expect(pos2.local.x).toBe(15);
   });
@@ -206,22 +258,28 @@ describe('EcsWorld', () => {
 
     const positionSystem: EcsSystem<[PositionEcsComponent]> = {
       query: [positionId],
-      run: vi.fn(
-        (result: { entity: number; components: [PositionEcsComponent] }) => {
-          const [position] = result.components;
-
-          position.local.x += 10;
+      update: vi.fn(
+        (
+          _world: EcsWorld,
+          { components: [positions] }: { components: [PositionEcsComponent[]] },
+        ) => {
+          for (const position of positions) {
+            position.local.x += 10;
+          }
         },
       ),
     };
 
     const rotationSystem: EcsSystem<[RotationEcsComponent]> = {
       query: [rotationId],
-      run: vi.fn(
-        (result: { entity: number; components: [RotationEcsComponent] }) => {
-          const [rotation] = result.components;
-
-          rotation.local *= 2;
+      update: vi.fn(
+        (
+          _world: EcsWorld,
+          { components: [rotations] }: { components: [RotationEcsComponent[]] },
+        ) => {
+          for (const rotation of rotations) {
+            rotation.local *= 2;
+          }
         },
       ),
     };
@@ -231,120 +289,13 @@ describe('EcsWorld', () => {
 
     world.update();
 
-    expect(positionSystem.run).toHaveBeenCalledTimes(2);
+    expect(positionSystem.update).toHaveBeenCalledTimes(1);
     expect(pos1.local.x).toBe(5);
     expect(pos2.local.x).toBe(15);
 
-    expect(rotationSystem.run).toHaveBeenCalledTimes(2);
+    expect(rotationSystem.update).toHaveBeenCalledTimes(1);
     expect(rot1.local).toBe(2);
     expect(rot2.local).toBe(4);
-  });
-
-  describe('afterRun', () => {
-    it('passes an array of every run call result to afterRun', () => {
-      const world = new EcsWorld();
-      const entity = world.createEntity();
-
-      world.addComponent(entity, positionId, {
-        local: Vector2.zero,
-        world: Vector2.zero,
-      });
-
-      const afterRun = vi.fn();
-      const system: EcsSystem<[PositionEcsComponent], null, string> = {
-        query: [positionId],
-        run: () => 'result-value',
-        afterRun,
-      };
-
-      world.addSystem(system);
-      world.update();
-
-      expect(afterRun).toHaveBeenCalledTimes(1);
-      expect(afterRun).toHaveBeenCalledWith(['result-value']);
-    });
-
-    it('does not throw when afterRun is not defined', () => {
-      const world = new EcsWorld();
-      const entity = world.createEntity();
-
-      world.addComponent(entity, positionId, {
-        local: Vector2.zero,
-        world: Vector2.zero,
-      });
-
-      const system: EcsSystem<[PositionEcsComponent]> = {
-        query: [positionId],
-        run: () => {},
-      };
-
-      world.addSystem(system);
-
-      expect(() => world.update()).not.toThrow();
-    });
-
-    // afterRun is a once-per-tick hook: every matched entity's run() call
-    // happens first, and afterRun is called exactly once afterwards with all
-    // of their results together, not interleaved with run per entity. This
-    // is what lets the render system collect one RenderPassResult per
-    // camera in run, then draw every camera's batch from a single afterRun
-    // call once all cameras are known.
-    it('calls run for every matched entity before calling afterRun once, with all their results', () => {
-      const world = new EcsWorld();
-      const entity1 = world.createEntity();
-      const entity2 = world.createEntity();
-
-      world.addComponent(entity1, positionId, {
-        local: Vector2.zero,
-        world: Vector2.zero,
-      });
-      world.addComponent(entity2, positionId, {
-        local: Vector2.zero,
-        world: Vector2.zero,
-      });
-
-      const callOrder: string[] = [];
-      const system: EcsSystem<[PositionEcsComponent], null, number> = {
-        query: [positionId],
-        run: (result) => {
-          callOrder.push(`run:${result.entity}`);
-
-          return result.entity;
-        },
-        afterRun: (entities) => {
-          callOrder.push(`afterRun:${entities.join(',')}`);
-        },
-      };
-
-      world.addSystem(system);
-      world.update();
-
-      expect(callOrder).toEqual([
-        `run:${entity1}`,
-        `run:${entity2}`,
-        `afterRun:${entity1},${entity2}`,
-      ]);
-    });
-
-    it('calls afterRun once with an empty array when no entities match the query', () => {
-      const world = new EcsWorld();
-      const nonexistentId = createComponentId<{ test: number }>(
-        'nonexistent-afterrun',
-      );
-
-      const afterRun = vi.fn();
-      const system: EcsSystem<[{ test: number }]> = {
-        query: [nonexistentId],
-        run: () => {},
-        afterRun,
-      };
-
-      world.addSystem(system);
-      world.update();
-
-      expect(afterRun).toHaveBeenCalledTimes(1);
-      expect(afterRun).toHaveBeenCalledWith([]);
-    });
   });
 
   describe('system registration lifecycle', () => {
@@ -353,7 +304,7 @@ describe('EcsWorld', () => {
       const onRegister = vi.fn();
       const system: EcsSystem<[]> = {
         query: [],
-        run: () => {},
+        update: () => {},
         onRegister,
       };
 
@@ -367,33 +318,33 @@ describe('EcsWorld', () => {
       const world = new EcsWorld();
       const system: EcsSystem<[]> = {
         query: [],
-        run: () => {},
+        update: () => {},
       };
 
       expect(() => world.addSystem(system)).not.toThrow();
     });
 
-    it('calls cleanupSystem with the world when a system is removed', () => {
+    it('calls cleanup with the world when a system is removed', () => {
       const world = new EcsWorld();
-      const cleanupSystem = vi.fn();
+      const cleanup = vi.fn();
       const system: EcsSystem<[]> = {
         query: [],
-        run: () => {},
-        cleanupSystem,
+        update: () => {},
+        cleanup,
       };
 
       world.addSystem(system);
       world.removeSystem(system);
 
-      expect(cleanupSystem).toHaveBeenCalledTimes(1);
-      expect(cleanupSystem).toHaveBeenCalledWith(world);
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(cleanup).toHaveBeenCalledWith(world);
     });
 
-    it('does not throw when removing a system without cleanupSystem', () => {
+    it('does not throw when removing a system without cleanup', () => {
       const world = new EcsWorld();
       const system: EcsSystem<[]> = {
         query: [],
-        run: () => {},
+        update: () => {},
       };
 
       world.addSystem(system);
@@ -401,38 +352,27 @@ describe('EcsWorld', () => {
       expect(() => world.removeSystem(system)).not.toThrow();
     });
 
-    it('calls cleanupEntities then cleanupSystem for every system when the world stops', () => {
+    it('calls cleanup with the world when it stops', () => {
       const world = new EcsWorld();
-      const entity = world.createEntity();
-
-      world.addComponent(entity, positionId, {
-        local: Vector2.zero,
-        world: Vector2.zero,
-      });
-
-      const callOrder: string[] = [];
-      const system: EcsSystem<[PositionEcsComponent]> = {
-        query: [positionId],
-        run: () => {},
-        cleanupEntities: () => {
-          callOrder.push('cleanupEntities');
-        },
-        cleanupSystem: () => {
-          callOrder.push('cleanupSystem');
-        },
+      const cleanup = vi.fn();
+      const system: EcsSystem<[]> = {
+        query: [],
+        update: () => {},
+        cleanup,
       };
 
       world.addSystem(system);
       world.stop();
 
-      expect(callOrder).toEqual(['cleanupEntities', 'cleanupSystem']);
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(cleanup).toHaveBeenCalledWith(world);
     });
 
-    it('does not throw when stopping a world whose systems define neither cleanupEntities nor cleanupSystem', () => {
+    it('does not throw when stopping a world whose systems define no cleanup', () => {
       const world = new EcsWorld();
       const system: EcsSystem<[]> = {
         query: [],
-        run: () => {},
+        update: () => {},
       };
 
       world.addSystem(system);

--- a/src/ecs/ecs-world.ts
+++ b/src/ecs/ecs-world.ts
@@ -1,71 +1,105 @@
-import { Stoppable, Updatable } from '../common/index.js';
+import { ComponentKey, TagKey } from '.';
+import { Stoppable, Updatable } from '../common';
+import { SortedSet, SparseSet } from '../utilities';
 import { ParameterizedForgeEvent } from '../events/parameterized-forge-event.js';
-import { SortedSet, SparseSet } from '../utilities/index.js';
-import { ComponentKey, TagKey } from './ecs-component.js';
 import { EcsSystem, SystemRegistrationOrder } from './ecs-system.js';
 
-export type QueryResult<T extends readonly unknown[]> = {
-  entity: number;
-  components: T;
-};
+export interface QueryResult<T extends readonly unknown[]> {
+  entities: readonly number[];
+  components: { [K in keyof T]: T[K][] };
+}
 
 export class EcsWorld implements Updatable, Stoppable {
   public readonly onEntityRemoved: ParameterizedForgeEvent<number>;
 
   private readonly _componentSets: Map<symbol, SparseSet<unknown>>;
-
   private readonly _freeEntityIds: number[] = [];
   private _nextEntityId = 0;
-
-  private readonly _queryResultBuffer: QueryResult<unknown[]> = {
-    entity: -1,
-    components: [],
-  };
-
-  private readonly _systems: SortedSet<EcsSystem<unknown[], unknown, unknown>>;
+  private readonly _systems: SortedSet<EcsSystem<readonly unknown[]>>;
 
   constructor() {
     this.onEntityRemoved = new ParameterizedForgeEvent('entityRemoved');
-
     this._componentSets = new Map();
     this._systems = new SortedSet();
   }
 
   public stop(): void {
     for (const system of this._systems) {
-      this.operate(system, (buffer) => system.cleanupEntities?.(buffer, this));
-
-      system.cleanupSystem?.(this);
+      system.cleanup?.(this);
     }
   }
 
-  public addSystem<T extends unknown[], K = null, A = void>(
-    system: EcsSystem<T, K, A>,
+  public addSystem<T extends readonly unknown[]>(
+    system: EcsSystem<T>,
     registrationOrder: number = SystemRegistrationOrder.normal,
   ): void {
     this._systems.add(system, registrationOrder);
-
     system.onRegister?.(this);
   }
 
-  public removeSystem<T extends unknown[], K, A>(
-    system: EcsSystem<T, K, A>,
+  public removeSystem<T extends readonly unknown[]>(
+    system: EcsSystem<T>,
   ): void {
     this._systems.delete(system);
-    system.cleanupSystem?.(this);
+    system.cleanup?.(this);
   }
 
   public update(): void {
     for (const system of this._systems) {
-      const beforeQueryResult = system.beforeQuery?.(this) ?? null;
-      const runResults: unknown[] = [];
-
-      this.operate(system, (buffer) => {
-        runResults.push(system.run(buffer, this, beforeQueryResult));
-      });
-
-      system.afterRun?.(runResults);
+      const results = this.query(system.query, system.tags);
+      system.update(this, results);
     }
+  }
+
+  public query<T extends readonly unknown[]>(
+    componentKeys: readonly ComponentKey<unknown>[],
+    tags: readonly TagKey[] = [],
+  ): QueryResult<T> {
+    const driver = this._getDriverComponentSet(componentKeys, tags);
+
+    if (!driver) {
+      return {
+        entities: [],
+        components: componentKeys.map(() => []) as unknown as {
+          [K in keyof T]: T[K][];
+        },
+      };
+    }
+
+    const matchedEntities: number[] = [];
+    const allKeys: readonly symbol[] = [...componentKeys, ...tags];
+
+    for (let i = 0; i < driver.size; i++) {
+      const entity = driver.denseEntities[i];
+
+      if (this._entityHasAllKeys(entity, allKeys)) {
+        matchedEntities.push(entity);
+      }
+    }
+
+    const componentArrays = componentKeys.map((key) => {
+      const set = this._componentSets.get(key)!;
+
+      return matchedEntities.map((entity) => set.get(entity));
+    });
+
+    return {
+      entities: matchedEntities,
+      components: componentArrays as unknown as { [K in keyof T]: T[K][] },
+    };
+  }
+
+  public createEntity(): number {
+    return this._generateEntityId();
+  }
+
+  public removeEntity(entity: number): void {
+    for (const componentSet of this._componentSets.values()) {
+      componentSet.remove(entity);
+    }
+
+    this.onEntityRemoved.raise(entity);
+    this._freeEntityIds.push(entity);
   }
 
   public addComponent<T>(
@@ -74,7 +108,6 @@ export class EcsWorld implements Updatable, Stoppable {
     componentData: T,
   ): T {
     const componentSet = this._getComponentOrCreateSetByKey(componentKey);
-
     componentSet.add(entity, componentData);
 
     return componentData;
@@ -82,7 +115,6 @@ export class EcsWorld implements Updatable, Stoppable {
 
   public addTag(entity: number, tagKey: TagKey): void {
     const componentSet = this._getComponentOrCreateSetByKey(tagKey, true);
-
     componentSet.add(entity, true);
   }
 
@@ -101,11 +133,10 @@ export class EcsWorld implements Updatable, Stoppable {
     componentKey: ComponentKey<T>,
   ): void {
     const componentSet = this._componentSets.get(componentKey);
-
     componentSet?.remove(entity);
 
-    for (const componentSet of this._componentSets.values()) {
-      if (componentSet.has(entity)) {
+    for (const set of this._componentSets.values()) {
+      if (set.has(entity)) {
         return;
       }
     }
@@ -114,86 +145,55 @@ export class EcsWorld implements Updatable, Stoppable {
     this._freeEntityIds.push(entity);
   }
 
-  public createEntity(): number {
-    const id = this._generateEntityId();
+  private _entityHasAllKeys(entity: number, keys: readonly symbol[]): boolean {
+    for (const key of keys) {
+      if (!this._componentSets.get(key)?.has(entity)) {
+        return false;
+      }
+    }
 
-    return id;
+    return true;
   }
 
-  public removeEntity(entity: number): void {
-    for (const componentSet of this._componentSets.values()) {
-      componentSet.remove(entity);
+  private _getDriverComponentSet(
+    componentKeys: readonly ComponentKey<unknown>[],
+    tags: readonly TagKey[] = [],
+  ): SparseSet<unknown> | null {
+    if (componentKeys.length === 0 && tags.length === 0) {
+      return null;
     }
 
-    this.onEntityRemoved.raise(entity);
-    this._freeEntityIds.push(entity);
+    let driver: SparseSet<unknown> | null = null;
+
+    for (const key of componentKeys) {
+      const componentSet = this._getComponentSet(key);
+
+      if (!componentSet) {
+        return null;
+      }
+
+      if (!driver || componentSet.size < driver.size) {
+        driver = componentSet;
+      }
+    }
+
+    for (const tagKey of tags) {
+      const componentSet = this._getComponentSet(tagKey);
+
+      if (!componentSet) {
+        return null;
+      }
+
+      if (!driver || componentSet.size < driver.size) {
+        driver = componentSet;
+      }
+    }
+
+    return driver;
   }
 
-  public operate(
-    system: EcsSystem<unknown[], unknown>,
-    callback: (queryResult: QueryResult<unknown[]>) => void,
-  ): void {
-    const driver = this._getDriverComponentSet(system.query, system.tags);
-
-    if (!driver) {
-      return;
-    }
-
-    for (let i = 0; i < driver.size; i++) {
-      const entity = driver.denseEntities[i];
-      let hasAll = true;
-
-      this._queryResultBuffer.components.length = 0;
-
-      for (const name of system.query) {
-        const set = this._componentSets.get(name);
-
-        if (!set?.has(entity)) {
-          hasAll = false;
-
-          break;
-        }
-
-        if (!set.isTag) {
-          this._queryResultBuffer.components.push(set.get(entity));
-        }
-      }
-
-      if (hasAll) {
-        this._queryResultBuffer.entity = entity;
-        callback(this._queryResultBuffer);
-      }
-    }
-  }
-
-  public queryEntities(componentNames: symbol[], out: number[]): void {
-    out.length = 0;
-
-    const driver = this._getDriverComponentSet(componentNames);
-
-    if (!driver) {
-      return;
-    }
-
-    for (let i = 0; i < driver.size; i++) {
-      const entity = driver.denseEntities[i];
-
-      let hasAllComponents = true;
-
-      for (const name of componentNames) {
-        const componentSet = this._componentSets.get(name);
-
-        if (!componentSet?.has(entity)) {
-          hasAllComponents = false;
-
-          break;
-        }
-      }
-
-      if (hasAllComponents) {
-        out.push(entity);
-      }
-    }
+  private _getComponentSet(componentName: symbol): SparseSet<unknown> | null {
+    return this._componentSets.get(componentName) ?? null;
   }
 
   private _getComponentOrCreateSetByKey<T>(
@@ -212,73 +212,12 @@ export class EcsWorld implements Updatable, Stoppable {
 
   private _generateEntityId(): number {
     if (this._freeEntityIds.length > 0) {
-      return this._freeEntityIds.pop() as number;
+      return this._freeEntityIds.pop()!;
     }
 
     const id = this._nextEntityId;
     this._nextEntityId += 1;
 
     return id;
-  }
-
-  private _getDriverComponentSet(
-    componentKeys: ComponentKey<unknown>[],
-    tags: TagKey[] = [],
-  ): SparseSet<unknown> | null {
-    if (componentKeys.length === 0) {
-      return null;
-    }
-
-    let driver: SparseSet<unknown> | null = this._getComponentSet(
-      componentKeys[0],
-    );
-
-    for (const name of componentKeys) {
-      const componentSet = this._getComponentSet(name);
-
-      if (!componentSet) {
-        continue;
-      }
-
-      if (!driver) {
-        driver = componentSet;
-
-        continue;
-      }
-
-      if (componentSet.size < driver.size) {
-        driver = componentSet;
-      }
-    }
-
-    for (const name of tags) {
-      const componentSet = this._getComponentSet(name);
-
-      if (!componentSet) {
-        continue;
-      }
-
-      if (!driver) {
-        driver = componentSet;
-
-        continue;
-      }
-
-      if (componentSet.size < driver.size) {
-        driver = componentSet;
-      }
-    }
-
-    return driver;
-  }
-
-  private _getComponentSet(componentName: symbol): SparseSet<unknown> | null {
-    const componentSet = this._componentSets.get(componentName);
-
-    if (!componentSet) {
-      return null;
-    }
-
-    return componentSet;
   }
 }

--- a/src/ecs/ecs-world.ts
+++ b/src/ecs/ecs-world.ts
@@ -1,6 +1,6 @@
-import { ComponentKey, TagKey } from '.';
-import { Stoppable, Updatable } from '../common';
-import { SortedSet, SparseSet } from '../utilities';
+import { ComponentKey, TagKey } from './ecs-component.js';
+import { Stoppable, Updatable } from '../common/index.js';
+import { SortedSet, SparseSet } from '../utilities/index.js';
 import { ParameterizedForgeEvent } from '../events/parameterized-forge-event.js';
 import { EcsSystem, SystemRegistrationOrder } from './ecs-system.js';
 

--- a/src/input/systems/reset-inputs-system.ts
+++ b/src/input/systems/reset-inputs-system.ts
@@ -11,8 +11,9 @@ export const createResetInputsEcsSystem = (): EcsSystem<
   [InputsEcsComponent]
 > => ({
   query: [inputsId],
-  run: (result) => {
-    const [inputsComponent] = result.components;
-    inputsComponent.inputManager.reset();
+  update: (_world, { components: [inputsComponents] }) => {
+    for (const inputsComponent of inputsComponents) {
+      inputsComponent.inputManager.reset();
+    }
   },
 });

--- a/src/input/systems/update-inputs-system.ts
+++ b/src/input/systems/update-inputs-system.ts
@@ -1,4 +1,4 @@
-import { Time } from '../../common';
+import { Time } from '../../common/index.js';
 import { EcsSystem } from '../../ecs/ecs-system.js';
 import {
   InputsEcsComponent,
@@ -12,8 +12,9 @@ export const createUpdateInputEcsSystem = (
   time: Time,
 ): EcsSystem<[InputsEcsComponent]> => ({
   query: [inputsId],
-  run: (result) => {
-    const [inputsComponent] = result.components;
-    inputsComponent.inputManager.update(time.deltaTimeInMilliseconds);
+  update: (_world, { components: [inputsComponents] }) => {
+    for (const inputsComponent of inputsComponents) {
+      inputsComponent.inputManager.update(time.deltaTimeInMilliseconds);
+    }
   },
 });

--- a/src/lifecycle/systems/lifetime-tracking-system.ts
+++ b/src/lifecycle/systems/lifetime-tracking-system.ts
@@ -1,4 +1,4 @@
-import { Time } from '../../common';
+import { Time } from '../../common/index.js';
 import { EcsSystem } from '../../ecs/ecs-system.js';
 import {
   LifetimeEcsComponent,
@@ -12,13 +12,15 @@ export const createLifetimeTrackingEcsSystem = (
   time: Time,
 ): EcsSystem<[LifetimeEcsComponent]> => ({
   query: [lifetimeId],
-  run: (result) => {
-    const [lifetimeComponent] = result.components;
+  update: (_world, { components: [lifetimeComponents] }) => {
+    for (const lifetimeComponent of lifetimeComponents) {
+      lifetimeComponent.elapsedSeconds += time.deltaTimeInSeconds;
 
-    lifetimeComponent.elapsedSeconds += time.deltaTimeInSeconds;
-
-    if (lifetimeComponent.elapsedSeconds >= lifetimeComponent.durationSeconds) {
-      lifetimeComponent.hasExpired = true;
+      if (
+        lifetimeComponent.elapsedSeconds >= lifetimeComponent.durationSeconds
+      ) {
+        lifetimeComponent.hasExpired = true;
+      }
     }
   },
 });

--- a/src/lifecycle/systems/remove-from-world-lifecycle-system.test.ts
+++ b/src/lifecycle/systems/remove-from-world-lifecycle-system.test.ts
@@ -30,12 +30,10 @@ describe('RemoveFromWorldLifecycleSystem', () => {
 
     world.update();
 
-    const entitiesMatchingQuery: number[] = [];
-
-    world.queryEntities(
-      [lifetimeId, RemoveFromWorldLifetimeStrategyId],
-      entitiesMatchingQuery,
-    );
+    const { entities: entitiesMatchingQuery } = world.query([
+      lifetimeId,
+      RemoveFromWorldLifetimeStrategyId,
+    ]);
 
     // Assert
     expect(entitiesMatchingQuery).toHaveLength(1);
@@ -54,12 +52,10 @@ describe('RemoveFromWorldLifecycleSystem', () => {
 
     world.update();
 
-    const entitiesMatchingQuery: number[] = [];
-
-    world.queryEntities(
-      [lifetimeId, RemoveFromWorldLifetimeStrategyId],
-      entitiesMatchingQuery,
-    );
+    const { entities: entitiesMatchingQuery } = world.query([
+      lifetimeId,
+      RemoveFromWorldLifetimeStrategyId,
+    ]);
 
     // Assert
     expect(entitiesMatchingQuery).toHaveLength(0);
@@ -82,12 +78,9 @@ describe('RemoveFromWorldLifecycleSystem', () => {
     time.update(0.1);
     world.update();
 
-    const entitiesMatchingQuery: number[] = [];
-
-    world.queryEntities(
-      [RemoveFromWorldLifetimeStrategyId],
-      entitiesMatchingQuery,
-    );
+    const { entities: entitiesMatchingQuery } = world.query([
+      RemoveFromWorldLifetimeStrategyId,
+    ]);
 
     // Assert
     expect(entitiesMatchingQuery).toHaveLength(1);

--- a/src/lifecycle/systems/remove-from-world-lifecycle-system.ts
+++ b/src/lifecycle/systems/remove-from-world-lifecycle-system.ts
@@ -14,11 +14,11 @@ export const createRemoveFromWorldEcsSystem = (): EcsSystem<
 > => ({
   query: [lifetimeId],
   tags: [RemoveFromWorldLifetimeStrategyId],
-  run: (result, world) => {
-    const [lifetimeComponent] = result.components;
-
-    if (lifetimeComponent.hasExpired) {
-      world.removeEntity(result.entity);
+  update: (world, { entities, components: [lifetimeComponents] }) => {
+    for (let i = 0; i < entities.length; i++) {
+      if (lifetimeComponents[i].hasExpired) {
+        world.removeEntity(entities[i]);
+      }
     }
   },
 });

--- a/src/particles/systems/particle-emitter-system.test.ts
+++ b/src/particles/systems/particle-emitter-system.test.ts
@@ -95,8 +95,7 @@ describe('ParticleEmitterSystem', () => {
     world.update();
 
     // Query for particles after they should have been created
-    const particlesAfter: number[] = [];
-    world.queryEntities([ParticleId], particlesAfter);
+    const { entities: particlesAfter } = world.query([ParticleId]);
 
     // Should have emitted 3 particles immediately (emitDurationSeconds: 0)
     expect(particlesAfter).toHaveLength(3);
@@ -126,8 +125,7 @@ describe('ParticleEmitterSystem', () => {
     time.update(100);
     world.update();
 
-    const particlesAfter: number[] = [];
-    world.queryEntities([ParticleId], particlesAfter);
+    const { entities: particlesAfter } = world.query([ParticleId]);
 
     const [particleEntity] = particlesAfter;
     const rotation = world.getComponent(particleEntity, rotationId);

--- a/src/particles/systems/particle-emitter-system.ts
+++ b/src/particles/systems/particle-emitter-system.ts
@@ -180,15 +180,15 @@ export const createParticleEcsSystem = (
   random: Random,
 ): EcsSystem<[ParticleEmitterEcsComponent]> => ({
   query: [ParticleEmitterId],
-  run: (result, world) => {
-    const [particleEmitterComponent] = result.components;
+  update: (world, { components: [particleEmitterComponents] }) => {
+    for (const particleEmitterComponent of particleEmitterComponents) {
+      for (const particleEmitter of particleEmitterComponent.emitters.values()) {
+        particleEmitter.currentEmitDuration += time.deltaTimeInSeconds;
 
-    for (const particleEmitter of particleEmitterComponent.emitters.values()) {
-      particleEmitter.currentEmitDuration += time.deltaTimeInSeconds;
+        startEmittingParticles(particleEmitter, random);
 
-      startEmittingParticles(particleEmitter, random);
-
-      emitNewParticles(particleEmitter, random, world);
+        emitNewParticles(particleEmitter, random, world);
+      }
     }
   },
 });

--- a/src/particles/systems/particle-position-system.ts
+++ b/src/particles/systems/particle-position-system.ts
@@ -26,24 +26,34 @@ export const createParticlePositionEcsSystem = (
   ]
 > => ({
   query: [positionId, rotationId, speedId, ParticleId],
-  run: (result) => {
-    const [
-      positionComponent,
-      rotationComponent,
-      speedComponent,
-      particleComponent,
-    ] = result.components;
+  update: (
+    _world,
+    {
+      components: [
+        positionComponents,
+        rotationComponents,
+        speedComponents,
+        particleComponents,
+      ],
+    },
+  ) => {
+    for (let i = 0; i < positionComponents.length; i++) {
+      const positionComponent = positionComponents[i];
+      const rotationComponent = rotationComponents[i];
+      const speedComponent = speedComponents[i];
+      const particleComponent = particleComponents[i];
 
-    positionComponent.local.x +=
-      speedComponent.speed *
-      time.deltaTimeInSeconds *
-      Math.sin(rotationComponent.local);
-    positionComponent.local.y -=
-      speedComponent.speed *
-      time.deltaTimeInSeconds *
-      Math.cos(rotationComponent.local);
+      positionComponent.local.x +=
+        speedComponent.speed *
+        time.deltaTimeInSeconds *
+        Math.sin(rotationComponent.local);
+      positionComponent.local.y -=
+        speedComponent.speed *
+        time.deltaTimeInSeconds *
+        Math.cos(rotationComponent.local);
 
-    rotationComponent.local +=
-      particleComponent.rotationSpeed * time.deltaTimeInSeconds;
+      rotationComponent.local +=
+        particleComponent.rotationSpeed * time.deltaTimeInSeconds;
+    }
   },
 });

--- a/src/physics/systems/angular-velocity-motor.system.ts
+++ b/src/physics/systems/angular-velocity-motor.system.ts
@@ -25,32 +25,35 @@ import { clamp } from '../../math/index.js';
  */
 export const createAngularVelocityMotorEcsSystem = (
   time: Time,
-): EcsSystem<
-  [AngularVelocityMotorEcsComponent, PhysicsBodyEcsComponent],
-  void
-> => ({
+): EcsSystem<[AngularVelocityMotorEcsComponent, PhysicsBodyEcsComponent]> => ({
   query: [AngularVelocityMotorId, PhysicsBodyId],
-  run: (result) => {
-    const [motorComponent, physicsBodyComponent] = result.components;
-    const { physicsBody } = physicsBodyComponent;
+  update: (
+    _world,
+    { components: [motorComponents, physicsBodyComponents] },
+  ) => {
     const { deltaTimeInSeconds } = time;
 
-    const responsiveness = physicsBody.inverseInertia * deltaTimeInSeconds;
+    for (let i = 0; i < motorComponents.length; i++) {
+      const motorComponent = motorComponents[i];
+      const { physicsBody } = physicsBodyComponents[i];
 
-    if (responsiveness <= 0) {
-      return;
+      const responsiveness = physicsBody.inverseInertia * deltaTimeInSeconds;
+
+      if (responsiveness <= 0) {
+        continue;
+      }
+
+      const desiredTorque =
+        (motorComponent.targetVelocity - physicsBody.angularVelocity) /
+        responsiveness;
+
+      const torque = clamp(
+        desiredTorque,
+        -motorComponent.maxTorque,
+        motorComponent.maxTorque,
+      );
+
+      physicsBody.applyTorque(torque, deltaTimeInSeconds);
     }
-
-    const desiredTorque =
-      (motorComponent.targetVelocity - physicsBody.angularVelocity) /
-      responsiveness;
-
-    const torque = clamp(
-      desiredTorque,
-      -motorComponent.maxTorque,
-      motorComponent.maxTorque,
-    );
-
-    physicsBody.applyTorque(torque, deltaTimeInSeconds);
   },
 });

--- a/src/physics/systems/linear-damper.system.ts
+++ b/src/physics/systems/linear-damper.system.ts
@@ -30,32 +30,34 @@ function pointVelocity(body: RigidBody, r: Vector2): Vector2 {
  */
 export const createLinearDamperEcsSystem = (
   time: Time,
-): EcsSystem<[LinearDamperEcsComponent], void> => ({
+): EcsSystem<[LinearDamperEcsComponent]> => ({
   query: [LinearDamperId],
-  run: (result) => {
-    const [damper] = result.components;
-    const { bodyA, bodyB, anchorA, anchorB, dampingCoefficient } = damper;
+  update: (_world, { components: [dampers] }) => {
     const { deltaTimeInSeconds } = time;
 
-    const rA = anchorA.rotate(bodyA.angle);
-    const rB = anchorB.rotate(bodyB.angle);
-    const delta = bodyB.position.add(rB).subtract(bodyA.position.add(rA));
-    const length = delta.magnitude();
+    for (const damper of dampers) {
+      const { bodyA, bodyB, anchorA, anchorB, dampingCoefficient } = damper;
 
-    if (length === 0) {
-      return;
+      const rA = anchorA.rotate(bodyA.angle);
+      const rB = anchorB.rotate(bodyB.angle);
+      const delta = bodyB.position.add(rB).subtract(bodyA.position.add(rA));
+      const length = delta.magnitude();
+
+      if (length === 0) {
+        continue;
+      }
+
+      const direction = delta.multiply(1 / length);
+      const closingSpeed = pointVelocity(bodyB, rB)
+        .subtract(pointVelocity(bodyA, rA))
+        .dot(direction);
+
+      const impulse = direction.multiply(
+        -dampingCoefficient * closingSpeed * deltaTimeInSeconds,
+      );
+
+      bodyA.applyImpulse(impulse.multiply(-1), rA);
+      bodyB.applyImpulse(impulse, rB);
     }
-
-    const direction = delta.multiply(1 / length);
-    const closingSpeed = pointVelocity(bodyB, rB)
-      .subtract(pointVelocity(bodyA, rA))
-      .dot(direction);
-
-    const impulse = direction.multiply(
-      -dampingCoefficient * closingSpeed * deltaTimeInSeconds,
-    );
-
-    bodyA.applyImpulse(impulse.multiply(-1), rA);
-    bodyB.applyImpulse(impulse, rB);
   },
 });

--- a/src/physics/systems/linear-spring.system.ts
+++ b/src/physics/systems/linear-spring.system.ts
@@ -23,29 +23,31 @@ import {
  */
 export const createLinearSpringEcsSystem = (
   time: Time,
-): EcsSystem<[LinearSpringEcsComponent], void> => ({
+): EcsSystem<[LinearSpringEcsComponent]> => ({
   query: [LinearSpringId],
-  run: (result) => {
-    const [spring] = result.components;
-    const { bodyA, bodyB, anchorA, anchorB, restLength, stiffness } = spring;
+  update: (_world, { components: [springs] }) => {
     const { deltaTimeInSeconds } = time;
 
-    const rA = anchorA.rotate(bodyA.angle);
-    const rB = anchorB.rotate(bodyB.angle);
-    const delta = bodyB.position.add(rB).subtract(bodyA.position.add(rA));
-    const length = delta.magnitude();
+    for (const spring of springs) {
+      const { bodyA, bodyB, anchorA, anchorB, restLength, stiffness } = spring;
 
-    if (length === 0) {
-      return;
+      const rA = anchorA.rotate(bodyA.angle);
+      const rB = anchorB.rotate(bodyB.angle);
+      const delta = bodyB.position.add(rB).subtract(bodyA.position.add(rA));
+      const length = delta.magnitude();
+
+      if (length === 0) {
+        continue;
+      }
+
+      const direction = delta.multiply(1 / length);
+      const displacement = length - restLength;
+      const impulse = direction.multiply(
+        -stiffness * displacement * deltaTimeInSeconds,
+      );
+
+      bodyA.applyImpulse(impulse.multiply(-1), rA);
+      bodyB.applyImpulse(impulse, rB);
     }
-
-    const direction = delta.multiply(1 / length);
-    const displacement = length - restLength;
-    const impulse = direction.multiply(
-      -stiffness * displacement * deltaTimeInSeconds,
-    );
-
-    bodyA.applyImpulse(impulse.multiply(-1), rA);
-    bodyB.applyImpulse(impulse, rB);
   },
 });

--- a/src/physics/systems/physics-sync.system.test.ts
+++ b/src/physics/systems/physics-sync.system.test.ts
@@ -240,7 +240,7 @@ describe('PhysicsSyncSystem', () => {
     expect(physicsWorld.bodies).not.toContain(physicsBody);
   });
 
-  it('should stop reacting to entity removal once the system has been removed from the world', () => {
+  it('releases every registered body and stops reacting to entity removal once the system is removed from the world', () => {
     const isolatedWorld = new EcsWorld();
     const isolatedPhysicsWorld = new PhysicsWorld({ gravity: Vector2.zero });
     const system = createPhysicsSyncEcsSystem(isolatedPhysicsWorld, time);
@@ -260,9 +260,12 @@ describe('PhysicsSyncSystem', () => {
     expect(isolatedPhysicsWorld.bodies).toContain(physicsBody);
 
     isolatedWorld.removeSystem(system);
-    isolatedWorld.removeEntity(entity);
 
-    expect(isolatedPhysicsWorld.bodies).toContain(physicsBody);
+    expect(isolatedPhysicsWorld.bodies).not.toContain(physicsBody);
+
+    // The system's onEntityRemoved listener was deregistered as part of
+    // removal, so this must not throw or try to remove the body again.
+    expect(() => isolatedWorld.removeEntity(entity)).not.toThrow();
   });
 
   it('should drive a kinematic body from ECS position/rotation without the body driving ECS back', () => {

--- a/src/physics/systems/physics-sync.system.ts
+++ b/src/physics/systems/physics-sync.system.ts
@@ -11,8 +11,6 @@ import type { RigidBody } from '../rigid-body.js';
 
 import { EcsSystem } from '../../ecs/ecs-system.js';
 
-const physicsEntityBuffer: number[] = [];
-
 /**
  * Creates an ECS system that steps `physicsWorld` and keeps it synchronized
  * with the ECS world: registers/removes each entity's `RigidBody` as its
@@ -29,8 +27,7 @@ export const createPhysicsSyncEcsSystem = (
   physicsWorld: PhysicsWorld,
   time: Time,
 ): EcsSystem<
-  [PhysicsBodyEcsComponent, PositionEcsComponent, RotationEcsComponent],
-  void
+  [PhysicsBodyEcsComponent, PositionEcsComponent, RotationEcsComponent]
 > => {
   // Keyed by entity rather than by `RigidBody` instance: `EcsWorld` recycles
   // entity ids as soon as an entity is removed, so a `PhysicsBodyId`
@@ -56,16 +53,13 @@ export const createPhysicsSyncEcsSystem = (
     onRegister: (world) => {
       world.onEntityRemoved.registerListener(onEntityRemovedListener);
     },
-    beforeQuery: (world) => {
-      world.queryEntities(
-        [PhysicsBodyId, positionId, rotationId],
-        physicsEntityBuffer,
-      );
-
-      for (const entity of physicsEntityBuffer) {
-        const physicsBodyComponent = world.getComponent(entity, PhysicsBodyId)!;
-
-        const { physicsBody } = physicsBodyComponent;
+    update: (
+      _world,
+      { entities, components: [physicsBodyComponents, positions, rotations] },
+    ) => {
+      for (let i = 0; i < entities.length; i++) {
+        const entity = entities[i];
+        const { physicsBody } = physicsBodyComponents[i];
 
         physicsWorld.addBody(physicsBody);
         registeredEntities.set(entity, physicsBody);
@@ -73,37 +67,34 @@ export const createPhysicsSyncEcsSystem = (
       }
 
       physicsWorld.step(time.deltaTimeInSeconds);
-    },
-    run: (result) => {
-      const [physicsBodyComponent, positionComponent, rotationComponent] =
-        result.components;
-      const { physicsBody } = physicsBodyComponent;
 
-      if (physicsBody.isStatic || physicsBodyComponent.isKinematic === true) {
-        physicsBody.position = positionComponent.world.clone();
+      for (let i = 0; i < entities.length; i++) {
+        const physicsBodyComponent = physicsBodyComponents[i];
+        const positionComponent = positions[i];
+        const rotationComponent = rotations[i];
+        const { physicsBody } = physicsBodyComponent;
 
-        // `rotationComponent.world` is in render space (Y-down), while
-        // `physicsBody.angle` is in world space (Y-up); these are mirrored,
-        // so the angle is negated when crossing this boundary.
-        physicsBody.angle = -rotationComponent.world;
-      } else {
-        positionComponent.world.x = physicsBody.position.x;
-        positionComponent.world.y = physicsBody.position.y;
+        if (physicsBody.isStatic || physicsBodyComponent.isKinematic === true) {
+          physicsBody.position = positionComponent.world.clone();
 
-        rotationComponent.world = -physicsBody.angle;
+          // `rotationComponent.world` is in render space (Y-down), while
+          // `physicsBody.angle` is in world space (Y-up); these are mirrored,
+          // so the angle is negated when crossing this boundary.
+          physicsBody.angle = -rotationComponent.world;
+        } else {
+          positionComponent.world.x = physicsBody.position.x;
+          positionComponent.world.y = physicsBody.position.y;
+
+          rotationComponent.world = -physicsBody.angle;
+        }
       }
     },
-    cleanupEntities: (result) => {
-      const { entity, components } = result;
-      const [physicsBodyComponent] = components;
-      const { physicsBody } = physicsBodyComponent;
-
-      if (registeredEntities.get(entity) === physicsBody) {
+    cleanup: (world) => {
+      for (const physicsBody of registeredEntities.values()) {
         physicsWorld.removeBody(physicsBody);
-        registeredEntities.delete(entity);
       }
-    },
-    cleanupSystem: (world) => {
+
+      registeredEntities.clear();
       world.onEntityRemoved.deregisterListener(onEntityRemovedListener);
     },
   };

--- a/src/physics/systems/prismatic-joint.system.test.ts
+++ b/src/physics/systems/prismatic-joint.system.test.ts
@@ -99,7 +99,7 @@ describe('PrismaticJointSystem', () => {
     expect(physicsWorld.joints).toContain(joint2);
   });
 
-  it('should stop reacting to entity removal once the system has been removed from the world', () => {
+  it('releases every registered joint and stops reacting to entity removal once the system is removed from the world', () => {
     const isolatedWorld = new EcsWorld();
     const isolatedPhysicsWorld = new PhysicsWorld({ gravity: Vector2.zero });
     const system = createPrismaticJointEcsSystem(isolatedPhysicsWorld);
@@ -116,8 +116,11 @@ describe('PrismaticJointSystem', () => {
     expect(isolatedPhysicsWorld.joints).toContain(joint);
 
     isolatedWorld.removeSystem(system);
-    isolatedWorld.removeEntity(entity);
 
-    expect(isolatedPhysicsWorld.joints).toContain(joint);
+    expect(isolatedPhysicsWorld.joints).not.toContain(joint);
+
+    // The system's onEntityRemoved listener was deregistered as part of
+    // removal, so this must not throw or try to remove the joint again.
+    expect(() => isolatedWorld.removeEntity(entity)).not.toThrow();
   });
 });

--- a/src/physics/systems/prismatic-joint.system.ts
+++ b/src/physics/systems/prismatic-joint.system.ts
@@ -6,8 +6,6 @@ import {
 import type { PrismaticJoint } from '../joints/index.js';
 import type { PhysicsWorld } from '../physics-world.js';
 
-const prismaticJointEntityBuffer: number[] = [];
-
 /**
  * Creates an ECS system that registers each entity's `PrismaticJoint` with
  * `physicsWorld` while the entity carries a `PrismaticJointId` component,
@@ -21,7 +19,7 @@ const prismaticJointEntityBuffer: number[] = [];
  */
 export const createPrismaticJointEcsSystem = (
   physicsWorld: PhysicsWorld,
-): EcsSystem<[PrismaticJointEcsComponent], void> => {
+): EcsSystem<[PrismaticJointEcsComponent]> => {
   // Keyed by entity rather than by `PrismaticJoint` instance for the same
   // reason as `createPhysicsSyncEcsSystem`'s `registeredEntities`: entity ids
   // are recycled as soon as an entity is removed, so a component
@@ -43,30 +41,21 @@ export const createPrismaticJointEcsSystem = (
     onRegister: (world) => {
       world.onEntityRemoved.registerListener(onEntityRemovedListener);
     },
-    beforeQuery: (world) => {
-      world.queryEntities([PrismaticJointId], prismaticJointEntityBuffer);
+    update: (_world, { entities, components: [jointComponents] }) => {
+      for (let i = 0; i < entities.length; i++) {
+        const entity = entities[i];
+        const { joint } = jointComponents[i];
 
-      for (const entity of prismaticJointEntityBuffer) {
-        const jointComponent = world.getComponent(entity, PrismaticJointId)!;
-
-        physicsWorld.addJoint(jointComponent.joint);
-        registeredEntities.set(entity, jointComponent.joint);
+        physicsWorld.addJoint(joint);
+        registeredEntities.set(entity, joint);
       }
     },
-    run: () => {
-      // Registration is handled in `beforeQuery`; a `PrismaticJoint` has no
-      // per-frame ECS-side state to sync.
-    },
-    cleanupEntities: (result) => {
-      const { entity, components } = result;
-      const [jointComponent] = components;
-
-      if (registeredEntities.get(entity) === jointComponent.joint) {
-        physicsWorld.removeJoint(jointComponent.joint);
-        registeredEntities.delete(entity);
+    cleanup: (world) => {
+      for (const joint of registeredEntities.values()) {
+        physicsWorld.removeJoint(joint);
       }
-    },
-    cleanupSystem: (world) => {
+
+      registeredEntities.clear();
       world.onEntityRemoved.deregisterListener(onEntityRemovedListener);
     },
   };

--- a/src/physics/systems/revolute-joint.system.test.ts
+++ b/src/physics/systems/revolute-joint.system.test.ts
@@ -99,7 +99,7 @@ describe('RevoluteJointSystem', () => {
     expect(physicsWorld.joints).toContain(joint2);
   });
 
-  it('should stop reacting to entity removal once the system has been removed from the world', () => {
+  it('releases every registered joint and stops reacting to entity removal once the system is removed from the world', () => {
     const isolatedWorld = new EcsWorld();
     const isolatedPhysicsWorld = new PhysicsWorld({ gravity: Vector2.zero });
     const system = createRevoluteJointEcsSystem(isolatedPhysicsWorld);
@@ -116,8 +116,11 @@ describe('RevoluteJointSystem', () => {
     expect(isolatedPhysicsWorld.joints).toContain(joint);
 
     isolatedWorld.removeSystem(system);
-    isolatedWorld.removeEntity(entity);
 
-    expect(isolatedPhysicsWorld.joints).toContain(joint);
+    expect(isolatedPhysicsWorld.joints).not.toContain(joint);
+
+    // The system's onEntityRemoved listener was deregistered as part of
+    // removal, so this must not throw or try to remove the joint again.
+    expect(() => isolatedWorld.removeEntity(entity)).not.toThrow();
   });
 });

--- a/src/physics/systems/revolute-joint.system.ts
+++ b/src/physics/systems/revolute-joint.system.ts
@@ -6,8 +6,6 @@ import {
 import type { RevoluteJoint } from '../joints/index.js';
 import type { PhysicsWorld } from '../physics-world.js';
 
-const revoluteJointEntityBuffer: number[] = [];
-
 /**
  * Creates an ECS system that registers each entity's `RevoluteJoint` with
  * `physicsWorld` while the entity carries a `RevoluteJointId` component, and
@@ -21,7 +19,7 @@ const revoluteJointEntityBuffer: number[] = [];
  */
 export const createRevoluteJointEcsSystem = (
   physicsWorld: PhysicsWorld,
-): EcsSystem<[RevoluteJointEcsComponent], void> => {
+): EcsSystem<[RevoluteJointEcsComponent]> => {
   // Keyed by entity rather than by `RevoluteJoint` instance for the same
   // reason as `createPhysicsSyncEcsSystem`'s `registeredEntities`: entity ids
   // are recycled as soon as an entity is removed, so a component
@@ -43,30 +41,21 @@ export const createRevoluteJointEcsSystem = (
     onRegister: (world) => {
       world.onEntityRemoved.registerListener(onEntityRemovedListener);
     },
-    beforeQuery: (world) => {
-      world.queryEntities([RevoluteJointId], revoluteJointEntityBuffer);
+    update: (_world, { entities, components: [jointComponents] }) => {
+      for (let i = 0; i < entities.length; i++) {
+        const entity = entities[i];
+        const { joint } = jointComponents[i];
 
-      for (const entity of revoluteJointEntityBuffer) {
-        const jointComponent = world.getComponent(entity, RevoluteJointId)!;
-
-        physicsWorld.addJoint(jointComponent.joint);
-        registeredEntities.set(entity, jointComponent.joint);
+        physicsWorld.addJoint(joint);
+        registeredEntities.set(entity, joint);
       }
     },
-    run: () => {
-      // Registration is handled in `beforeQuery`; a `RevoluteJoint` has no
-      // per-frame ECS-side state to sync.
-    },
-    cleanupEntities: (result) => {
-      const { entity, components } = result;
-      const [jointComponent] = components;
-
-      if (registeredEntities.get(entity) === jointComponent.joint) {
-        physicsWorld.removeJoint(jointComponent.joint);
-        registeredEntities.delete(entity);
+    cleanup: (world) => {
+      for (const joint of registeredEntities.values()) {
+        physicsWorld.removeJoint(joint);
       }
-    },
-    cleanupSystem: (world) => {
+
+      registeredEntities.clear();
       world.onEntityRemoved.deregisterListener(onEntityRemovedListener);
     },
   };

--- a/src/rendering/systems/bloom-system.test.ts
+++ b/src/rendering/systems/bloom-system.test.ts
@@ -468,7 +468,7 @@ describe('createBloomEcsSystem', () => {
     });
   });
 
-  describe('cleanupEntities', () => {
+  describe('cleanup', () => {
     it('disposes the scratch bright, ping-pong, and composite targets when the world stops', () => {
       const target = new RenderTarget(mockGl, 128, 128);
 

--- a/src/rendering/systems/bloom-system.ts
+++ b/src/rendering/systems/bloom-system.ts
@@ -54,7 +54,7 @@ const verticalBlurDirection = new Float32Array([0, 1]);
  */
 export const createBloomEcsSystem = (
   renderContext: RenderContext,
-): EcsSystem<[CameraEcsComponent, BloomEcsComponent], void, void> => {
+): EcsSystem<[CameraEcsComponent, BloomEcsComponent]> => {
   const { gl, shaderCache } = renderContext;
 
   const thresholdMaterial = new Material(
@@ -83,7 +83,7 @@ export const createBloomEcsSystem = (
   // downsampled (see `bloomDownsampleFactor`); `compositeTarget` matches the
   // camera's `renderTarget` resolution, since the composite pass's output
   // replaces that target's contents. Owned by this system (not module-level
-  // state) and disposed via `cleanupEntities` when the world stops.
+  // state) and disposed via `cleanup` when the world stops.
   const brightTargetByTarget = new WeakMap<RenderTarget, RenderTarget>();
   const pingPongByTarget = new WeakMap<RenderTarget, PingPongTarget>();
   const compositeTargetByTarget = new WeakMap<RenderTarget, RenderTarget>();
@@ -190,100 +190,113 @@ export const createBloomEcsSystem = (
 
   return {
     query: [cameraId, bloomId],
-    beforeQuery: () => {
+    update: (_world, { components: [cameras, blooms] }) => {
       processedTargetsThisFrame.clear();
-    },
-    run: (result) => {
-      const [camera, bloom] = result.components;
-      const { renderTarget } = camera;
-      const intensity = Math.max(0, bloom.intensity);
 
-      if (
-        !renderTarget ||
-        intensity <= 0 ||
-        processedTargetsThisFrame.has(renderTarget)
-      ) {
-        return;
-      }
+      for (let i = 0; i < cameras.length; i++) {
+        const camera = cameras[i];
+        const bloom = blooms[i];
+        const { renderTarget } = camera;
+        const intensity = Math.max(0, bloom.intensity);
 
-      processedTargetsThisFrame.add(renderTarget);
+        if (
+          !renderTarget ||
+          intensity <= 0 ||
+          processedTargetsThisFrame.has(renderTarget)
+        ) {
+          continue;
+        }
 
-      const brightTarget = getBrightTarget(renderTarget);
+        processedTargetsThisFrame.add(renderTarget);
 
-      beginFullscreenReplacePass(renderContext, brightTarget);
+        const brightTarget = getBrightTarget(renderTarget);
 
-      thresholdMaterial.setUniform('u_texture', renderTarget.colorTexture);
-      thresholdMaterial.setUniform('u_threshold', bloom.threshold);
-      thresholdMaterial.setUniform(
-        'u_texelSize',
-        new Float32Array([1 / renderTarget.width, 1 / renderTarget.height]),
-      );
+        beginFullscreenReplacePass(renderContext, brightTarget);
 
-      drawFullscreenQuad(renderContext, thresholdMaterial);
+        thresholdMaterial.setUniform('u_texture', renderTarget.colorTexture);
+        thresholdMaterial.setUniform('u_threshold', bloom.threshold);
+        thresholdMaterial.setUniform(
+          'u_texelSize',
+          new Float32Array([1 / renderTarget.width, 1 / renderTarget.height]),
+        );
 
-      const pingPong = getPingPongTarget(renderTarget);
-      const texelSize = new Float32Array([
-        1 / brightTarget.width,
-        1 / brightTarget.height,
-      ]);
+        drawFullscreenQuad(renderContext, thresholdMaterial);
 
-      // Same two-pass separable technique as createGaussianBlurEcsSystem:
-      // each iteration reads the previous iteration's result back out of
-      // `brightTarget` and writes the next, more-blurred version back into
-      // it, so `passes` composes into a wider glow. Running at the
-      // downsampled resolution (see `bloomDownsampleFactor`) is what makes
-      // that glow actually reach past a sprite's edges instead of staying
-      // pinned to its source pixels.
-      for (let i = 0; i < bloom.passes; i++) {
-        drawBlurPass(
+        const pingPong = getPingPongTarget(renderTarget);
+        const texelSize = new Float32Array([
+          1 / brightTarget.width,
+          1 / brightTarget.height,
+        ]);
+
+        // Same two-pass separable technique as createGaussianBlurEcsSystem:
+        // each iteration reads the previous iteration's result back out of
+        // `brightTarget` and writes the next, more-blurred version back into
+        // it, so `passes` composes into a wider glow. Running at the
+        // downsampled resolution (see `bloomDownsampleFactor`) is what makes
+        // that glow actually reach past a sprite's edges instead of staying
+        // pinned to its source pixels.
+        for (let p = 0; p < bloom.passes; p++) {
+          drawBlurPass(
+            brightTarget.colorTexture,
+            horizontalBlurDirection,
+            texelSize,
+            pingPong.write,
+          );
+          pingPong.swap();
+
+          drawBlurPass(
+            pingPong.read.colorTexture,
+            verticalBlurDirection,
+            texelSize,
+            brightTarget,
+          );
+        }
+
+        // The composite pass upsamples `brightTarget` back to full resolution
+        // implicitly, via the bloom texture's own linear-filtered sampling.
+        // It writes into its own full-resolution scratch buffer rather than
+        // `pingPong` (now downsampled) or `renderTarget` (the scene texture
+        // it's reading from, which can't also be this draw's destination).
+        const compositeTarget = getCompositeTarget(renderTarget);
+
+        beginFullscreenReplacePass(renderContext, compositeTarget);
+
+        compositeMaterial.setUniform(
+          'u_sceneTexture',
+          renderTarget.colorTexture,
+        );
+        compositeMaterial.setUniform(
+          'u_bloomTexture',
           brightTarget.colorTexture,
-          horizontalBlurDirection,
-          texelSize,
-          pingPong.write,
         );
-        pingPong.swap();
+        compositeMaterial.setUniform('u_intensity', intensity);
 
-        drawBlurPass(
-          pingPong.read.colorTexture,
-          verticalBlurDirection,
-          texelSize,
-          brightTarget,
-        );
+        drawFullscreenQuad(renderContext, compositeMaterial);
+
+        copyTexture(compositeTarget.colorTexture, renderTarget);
       }
-
-      // The composite pass upsamples `brightTarget` back to full resolution
-      // implicitly, via the bloom texture's own linear-filtered sampling.
-      // It writes into its own full-resolution scratch buffer rather than
-      // `pingPong` (now downsampled) or `renderTarget` (the scene texture
-      // it's reading from, which can't also be this draw's destination).
-      const compositeTarget = getCompositeTarget(renderTarget);
-
-      beginFullscreenReplacePass(renderContext, compositeTarget);
-
-      compositeMaterial.setUniform('u_sceneTexture', renderTarget.colorTexture);
-      compositeMaterial.setUniform('u_bloomTexture', brightTarget.colorTexture);
-      compositeMaterial.setUniform('u_intensity', intensity);
-
-      drawFullscreenQuad(renderContext, compositeMaterial);
-
-      copyTexture(compositeTarget.colorTexture, renderTarget);
     },
-    cleanupEntities: (result) => {
-      const [camera] = result.components;
-      const { renderTarget } = camera;
+    cleanup: (world) => {
+      const {
+        components: [cameras],
+      } = world.query<[CameraEcsComponent]>([cameraId, bloomId]);
 
-      if (!renderTarget) {
-        return;
+      for (const camera of cameras) {
+        const { renderTarget } = camera;
+
+        if (!renderTarget) {
+          continue;
+        }
+
+        brightTargetByTarget.get(renderTarget)?.dispose(gl);
+        brightTargetByTarget.delete(renderTarget);
+
+        pingPongByTarget.get(renderTarget)?.dispose(gl);
+        pingPongByTarget.delete(renderTarget);
+
+        compositeTargetByTarget.get(renderTarget)?.dispose(gl);
+        compositeTargetByTarget.delete(renderTarget);
       }
-
-      brightTargetByTarget.get(renderTarget)?.dispose(gl);
-      brightTargetByTarget.delete(renderTarget);
-
-      pingPongByTarget.get(renderTarget)?.dispose(gl);
-      pingPongByTarget.delete(renderTarget);
-
-      compositeTargetByTarget.get(renderTarget)?.dispose(gl);
-      compositeTargetByTarget.delete(renderTarget);
     },
   };
 };

--- a/src/rendering/systems/camera-system.ts
+++ b/src/rendering/systems/camera-system.ts
@@ -12,39 +12,42 @@ export const createCameraEcsSystem = (
   time: Time,
 ): EcsSystem<[CameraEcsComponent, PositionEcsComponent]> => ({
   query: [cameraId, positionId],
-  run: (result) => {
-    const [cameraComponent, position] = result.components;
+  update: (_world, { components: [cameraComponents, positions] }) => {
+    for (let i = 0; i < cameraComponents.length; i++) {
+      const cameraComponent = cameraComponents[i];
+      const position = positions[i];
 
-    const {
-      isStatic,
-      zoomInput,
-      zoom,
-      minZoom,
-      maxZoom,
-      zoomSensitivity,
-      panInput,
-    } = cameraComponent;
+      const {
+        isStatic,
+        zoomInput,
+        zoom,
+        minZoom,
+        maxZoom,
+        zoomSensitivity,
+        panInput,
+      } = cameraComponent;
 
-    if (isStatic) {
-      return;
-    }
+      if (isStatic) {
+        continue;
+      }
 
-    if (zoomInput) {
-      // Use multiplicative (exponential) scaling so scrolling has consistent effect
-      // regardless of current zoom level. Positive zoomInput.value will reduce zoom,
-      // negative will increase it.
-      const scaleFactor = Math.pow(1 + zoomSensitivity, -zoomInput.value);
-      cameraComponent.zoom = math.clamp(zoom * scaleFactor, minZoom, maxZoom);
-    }
+      if (zoomInput) {
+        // Use multiplicative (exponential) scaling so scrolling has consistent effect
+        // regardless of current zoom level. Positive zoomInput.value will reduce zoom,
+        // negative will increase it.
+        const scaleFactor = Math.pow(1 + zoomSensitivity, -zoomInput.value);
+        cameraComponent.zoom = math.clamp(zoom * scaleFactor, minZoom, maxZoom);
+      }
 
-    if (panInput) {
-      const zoomPanMultiplier =
-        cameraComponent.panSensitivity *
-        (1 / cameraComponent.zoom) *
-        time.rawDeltaTimeInMilliseconds;
+      if (panInput) {
+        const zoomPanMultiplier =
+          cameraComponent.panSensitivity *
+          (1 / cameraComponent.zoom) *
+          time.rawDeltaTimeInMilliseconds;
 
-      position.local.y += panInput.value.y * zoomPanMultiplier;
-      position.local.x += panInput.value.x * zoomPanMultiplier;
+        position.local.y += panInput.value.y * zoomPanMultiplier;
+        position.local.x += panInput.value.x * zoomPanMultiplier;
+      }
     }
   },
 });

--- a/src/rendering/systems/gaussian-blur-system.test.ts
+++ b/src/rendering/systems/gaussian-blur-system.test.ts
@@ -370,7 +370,7 @@ describe('createGaussianBlurEcsSystem', () => {
     expect(mockGl.disable).toHaveBeenCalledWith(mockGl.BLEND);
   });
 
-  describe('cleanupEntities', () => {
+  describe('cleanup', () => {
     it('disposes the scratch ping-pong target when the world stops', () => {
       const target = new RenderTarget(mockGl, 128, 128);
 

--- a/src/rendering/systems/gaussian-blur-system.ts
+++ b/src/rendering/systems/gaussian-blur-system.ts
@@ -39,7 +39,7 @@ const verticalBlurDirection = new Float32Array([0, 1]);
  */
 export const createGaussianBlurEcsSystem = (
   renderContext: RenderContext,
-): EcsSystem<[CameraEcsComponent, GaussianBlurEcsComponent], void, void> => {
+): EcsSystem<[CameraEcsComponent, GaussianBlurEcsComponent]> => {
   const { gl, shaderCache } = renderContext;
 
   const blurMaterial = new Material(
@@ -60,7 +60,7 @@ export const createGaussianBlurEcsSystem = (
 
   // Scratch GPU resources, one entry per distinct `renderTarget` in use by a
   // blurred camera, sized to match it and recreated on resize. Owned by this
-  // system (not module-level state) and disposed via `cleanupEntities` when
+  // system (not module-level state) and disposed via `cleanup` when
   // the world stops.
   const pingPongByTarget = new WeakMap<RenderTarget, PingPongTarget>();
   const sharpSnapshotByTarget = new WeakMap<RenderTarget, RenderTarget>();
@@ -149,95 +149,105 @@ export const createGaussianBlurEcsSystem = (
 
   return {
     query: [cameraId, gaussianBlurId],
-    beforeQuery: () => {
+    update: (_world, { components: [cameras, blurs] }) => {
       processedTargetsThisFrame.clear();
-    },
-    run: (result) => {
-      const [camera, blur] = result.components;
-      const { renderTarget } = camera;
-      const intensity = Math.min(1, Math.max(0, blur.intensity));
 
-      if (
-        !renderTarget ||
-        intensity <= 0 ||
-        processedTargetsThisFrame.has(renderTarget)
-      ) {
-        return;
-      }
+      for (let i = 0; i < cameras.length; i++) {
+        const camera = cameras[i];
+        const blur = blurs[i];
+        const { renderTarget } = camera;
+        const intensity = Math.min(1, Math.max(0, blur.intensity));
 
-      processedTargetsThisFrame.add(renderTarget);
+        if (
+          !renderTarget ||
+          intensity <= 0 ||
+          processedTargetsThisFrame.has(renderTarget)
+        ) {
+          continue;
+        }
 
-      const needsBlend = intensity < 1;
-      const sharpSnapshot = needsBlend
-        ? getSharpSnapshotTarget(renderTarget)
-        : null;
+        processedTargetsThisFrame.add(renderTarget);
 
-      if (sharpSnapshot) {
-        copyTexture(renderTarget.colorTexture, sharpSnapshot);
-      }
+        const needsBlend = intensity < 1;
+        const sharpSnapshot = needsBlend
+          ? getSharpSnapshotTarget(renderTarget)
+          : null;
 
-      const pingPong = getPingPongTarget(renderTarget);
-      const texelSize = new Float32Array([
-        1 / renderTarget.width,
-        1 / renderTarget.height,
-      ]);
+        if (sharpSnapshot) {
+          copyTexture(renderTarget.colorTexture, sharpSnapshot);
+        }
 
-      // Each iteration reads the previous iteration's result back out of
-      // `renderTarget` (itself, for the first iteration, the freshly
-      // rendered scene) and writes the next, more-blurred version back
-      // into it, so `passes` composes into a wider blur without ever
-      // widening the individual 9-tap kernel.
-      for (let i = 0; i < blur.passes; i++) {
-        drawPass(
-          blurMaterial,
-          renderTarget.colorTexture,
-          horizontalBlurDirection,
-          texelSize,
-          pingPong.write,
+        const pingPong = getPingPongTarget(renderTarget);
+        const texelSize = new Float32Array([
+          1 / renderTarget.width,
+          1 / renderTarget.height,
+        ]);
+
+        // Each iteration reads the previous iteration's result back out of
+        // `renderTarget` (itself, for the first iteration, the freshly
+        // rendered scene) and writes the next, more-blurred version back
+        // into it, so `passes` composes into a wider blur without ever
+        // widening the individual 9-tap kernel.
+        for (let p = 0; p < blur.passes; p++) {
+          drawPass(
+            blurMaterial,
+            renderTarget.colorTexture,
+            horizontalBlurDirection,
+            texelSize,
+            pingPong.write,
+          );
+          pingPong.swap();
+
+          drawPass(
+            blurMaterial,
+            pingPong.read.colorTexture,
+            verticalBlurDirection,
+            texelSize,
+            renderTarget,
+          );
+        }
+
+        if (!sharpSnapshot) {
+          continue;
+        }
+
+        // Cross-fade the untouched sharp snapshot into the fully-blurred
+        // result, into a scratch buffer (safe to reuse now that the loop
+        // above is done with it), then copy that blend back into
+        // `renderTarget`, since consumers (like the present system) always
+        // read the blur's output from there.
+        beginFullscreenReplacePass(renderContext, pingPong.write);
+
+        crossFadeMaterial.setUniform(
+          'u_fromTexture',
+          sharpSnapshot.colorTexture,
         );
-        pingPong.swap();
+        crossFadeMaterial.setUniform('u_toTexture', renderTarget.colorTexture);
+        crossFadeMaterial.setUniform('u_factor', intensity);
 
-        drawPass(
-          blurMaterial,
-          pingPong.read.colorTexture,
-          verticalBlurDirection,
-          texelSize,
-          renderTarget,
-        );
+        drawFullscreenQuad(renderContext, crossFadeMaterial);
+
+        copyTexture(pingPong.write.colorTexture, renderTarget);
       }
-
-      if (!sharpSnapshot) {
-        return;
-      }
-
-      // Cross-fade the untouched sharp snapshot into the fully-blurred
-      // result, into a scratch buffer (safe to reuse now that the loop
-      // above is done with it), then copy that blend back into
-      // `renderTarget`, since consumers (like the present system) always
-      // read the blur's output from there.
-      beginFullscreenReplacePass(renderContext, pingPong.write);
-
-      crossFadeMaterial.setUniform('u_fromTexture', sharpSnapshot.colorTexture);
-      crossFadeMaterial.setUniform('u_toTexture', renderTarget.colorTexture);
-      crossFadeMaterial.setUniform('u_factor', intensity);
-
-      drawFullscreenQuad(renderContext, crossFadeMaterial);
-
-      copyTexture(pingPong.write.colorTexture, renderTarget);
     },
-    cleanupEntities: (result) => {
-      const [camera] = result.components;
-      const { renderTarget } = camera;
+    cleanup: (world) => {
+      const {
+        components: [cameras],
+      } = world.query<[CameraEcsComponent]>([cameraId, gaussianBlurId]);
 
-      if (!renderTarget) {
-        return;
+      for (const camera of cameras) {
+        const { renderTarget } = camera;
+
+        if (!renderTarget) {
+          continue;
+        }
+
+        pingPongByTarget.get(renderTarget)?.dispose(gl);
+        pingPongByTarget.delete(renderTarget);
+
+        sharpSnapshotByTarget.get(renderTarget)?.dispose(gl);
+        sharpSnapshotByTarget.delete(renderTarget);
       }
-
-      pingPongByTarget.get(renderTarget)?.dispose(gl);
-      pingPongByTarget.delete(renderTarget);
-
-      sharpSnapshotByTarget.get(renderTarget)?.dispose(gl);
-      sharpSnapshotByTarget.delete(renderTarget);
     },
   };
 };

--- a/src/rendering/systems/present-system.ts
+++ b/src/rendering/systems/present-system.ts
@@ -29,16 +29,16 @@ interface PresentCommand {
  * every subsequent (higher) layer alpha-blends on top instead, so later
  * layers don't erase earlier ones.
  *
- * `run` only gathers each camera's `renderTarget` and `layer`; `afterRun`
- * dedupes and sorts them once every camera has run, then does the actual
- * presenting, since the draw order depends on every camera's `layer` and
- * can only be resolved once the whole tick's cameras are known.
+ * `update` first gathers each camera's `renderTarget` and `layer`, then
+ * dedupes and sorts them, then does the actual presenting, since the draw
+ * order depends on every camera's `layer` and can only be resolved once the
+ * whole tick's cameras are known.
  * @param renderContext The rendering context
  * @returns The present ECS system
  */
 export const createPresentEcsSystem = (
   renderContext: RenderContext,
-): EcsSystem<[CameraEcsComponent], null, PresentCommand | null> => {
+): EcsSystem<[CameraEcsComponent]> => {
   const { gl, shaderCache } = renderContext;
 
   const material = new Material(
@@ -49,27 +49,19 @@ export const createPresentEcsSystem = (
 
   return {
     query: [cameraId],
-    run: (result) => {
-      const [camera] = result.components;
-      const { renderTarget, layer } = camera;
-
-      if (!renderTarget) {
-        return null;
-      }
-
-      return { layer, renderTarget };
-    },
-    afterRun: (results) => {
+    update: (_world, { components: [cameras] }) => {
       const targetsSeen = new Set<RenderTarget>();
       const presentCommands: PresentCommand[] = [];
 
-      for (const command of results) {
-        if (!command || targetsSeen.has(command.renderTarget)) {
+      for (const camera of cameras) {
+        const { renderTarget, layer } = camera;
+
+        if (!renderTarget || targetsSeen.has(renderTarget)) {
           continue;
         }
 
-        targetsSeen.add(command.renderTarget);
-        presentCommands.push(command);
+        targetsSeen.add(renderTarget);
+        presentCommands.push({ layer, renderTarget });
       }
 
       presentCommands.sort((a, b) => a.layer - b.layer);

--- a/src/rendering/systems/render-system.ts
+++ b/src/rendering/systems/render-system.ts
@@ -22,28 +22,9 @@ import { RenderTarget } from '../render-target.js';
 import { Renderable } from '../renderable.js';
 import { createProjectionMatrix } from '../shaders/index.js';
 import { RenderCommand } from '../render-command.js';
-import { Color } from '../color.js';
 import { calculatePixelsPerUnit } from '../utilities/calculate-pixels-per-unit.js';
 import { computeNineSliceRegions } from '../utilities/compute-nine-slice-regions.js';
-
-/**
- * The result of a single camera's `run` pass. `afterRun` receives one of
- * these per camera, once every camera has run, and uses it to bind the
- * correct draw destination before issuing that camera's batched draw calls.
- */
-export interface RenderPassResult {
-  /** The camera's projection matrix, applied to every draw call in this pass. */
-  projectionMatrix: Matrix3x3;
-
-  /** The render target to draw into, or `null` to draw onto the canvas. */
-  target: RenderTarget | null;
-
-  /** This camera's sprite draw commands, gathered by `run`. */
-  commands: RenderCommand[];
-
-  /** The clear color */
-  clearColor: Color;
-}
+import { EcsWorld } from '../../ecs/index.js';
 
 const setupInstanceAttributesAndDraw = (
   renderContext: RenderContext,
@@ -53,12 +34,11 @@ const setupInstanceAttributesAndDraw = (
   const { gl } = renderContext;
 
   gl.bindBuffer(gl.ARRAY_BUFFER, renderContext.instanceBuffer);
-
   renderable.setupInstanceAttributes(gl, renderable);
 
-  gl.enable(gl.BLEND); // TODO: Potential improvement - move blend state to material-specific configuration.
-  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA); // TODO: Potential improvement - centralize blend setup to avoid duplicate state calls.
-  gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, batchLength); // TODO: Potential improvement - avoid hard-coded quad vertex count for non-quad sprites.
+  gl.enable(gl.BLEND);
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+  gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, batchLength);
 };
 
 let instanceDataBuffer = new Float32Array(0);
@@ -79,11 +59,10 @@ const includeBatch = (
   batchEnd: number,
 ) => {
   const { gl } = renderContext;
-  const { renderable } = commands[batchStart]; // It is safe to assume all commands in the batch share the same renderable.
+  const { renderable } = commands[batchStart];
   const batchLength = batchEnd - batchStart;
 
   renderable.material.setUniform('u_projection', projectionMatrix);
-
   renderable.bind(gl);
 
   const requiredBatchSize = batchLength * renderable.floatsPerInstance;
@@ -101,32 +80,14 @@ const includeBatch = (
     instanceDataOffset += renderable.floatsPerInstance;
   }
 
-  // Upload instance transform buffer
   gl.bindBuffer(gl.ARRAY_BUFFER, renderContext.instanceBuffer);
   gl.bufferData(gl.ARRAY_BUFFER, buffer, gl.DYNAMIC_DRAW, 0, requiredBatchSize);
 
   setupInstanceAttributesAndDraw(renderContext, renderable, batchLength);
 };
 
-const spriteEntityBuffer: number[] = [];
-
-/**
- * The pivot every nine-slice region is drawn with: each region is its own
- * quad, so it's always centered on its own computed offset rather than
- * inheriting the parent sprite's pivot (which `computeNineSliceRegions`
- * already folds into that offset).
- */
 const centeredPivot = new Vector2(0.5, 0.5);
 
-/**
- * Pushes one `RenderCommand` for a normal sprite, or - when `spriteComponent`
- * has `slices` set - one `RenderCommand` per nine-slice region, each a
- * separate quad positioned and sized to reproduce the sliced layout. Every
- * region shares the entity's own rotation, scale and flip components; only
- * their position (offset around the entity, then rotated and scaled the
- * same way the shader would rotate/scale a single quad) and their
- * sprite-shaped size/pivot/UV rect differ per region.
- */
 const pushSpriteRenderCommands = (
   commands: RenderCommand[],
   spriteComponent: SpriteEcsComponent,
@@ -171,15 +132,6 @@ const pushSpriteRenderCommands = (
     (scaleComponent?.world.y ?? 1) * (flipComponent?.flipY ? -1 : 1);
 
   for (const region of regions) {
-    // Negated relative to a_instanceRot's own rotation of the region's local
-    // quad in the shader (see sprite.vert.glsl): that rotation acts on
-    // unnegated local geometry, so it picks up exactly one Y flip from the
-    // projection matrix, while this offset gets added into world position
-    // and then flows through bindSpriteInstanceData's world.y negation *and*
-    // the projection matrix's - two flips, i.e. none overall. Rotating this
-    // offset by the same (unnegated) angle would orbit each region around
-    // the entity in the opposite screen direction from how the shader spins
-    // that region's own quad, tearing the sliced sprite apart as it rotates.
     const regionOffset = new Vector2(
       region.offset.x * scaleX,
       region.offset.y * scaleY,
@@ -214,168 +166,133 @@ const pushSpriteRenderCommands = (
   }
 };
 
-/**
- * One `RenderCommand[]` per camera visited this tick, indexed by that
- * camera's position in query order (reset via `cameraIndex`, not by
- * identity), and reused across ticks so a stable number of cameras never
- * reallocates. `run` can't share a single buffer across cameras the way a
- * once-per-entity hook could, since every camera's commands need to survive
- * until `afterRun` draws all of them together.
- */
-const commandBuffersByCameraIndex: RenderCommand[][] = [];
-let cameraIndex = 0;
+function buildCameraCommands(
+  world: EcsWorld,
+  sprites: SpriteEcsComponent[],
+  spritePositions: PositionEcsComponent[],
+  spriteEntities: readonly number[],
+  cullingMask: number,
+  commands: RenderCommand[],
+): void {
+  for (let s = 0; s < spriteEntities.length; s++) {
+    const spriteComponent = sprites[s];
 
-/**
- * Tracks which destinations (a `RenderTarget`, or `null` for the canvas)
- * have already been cleared this frame, so multiple cameras that share a
- * destination (for example a static background camera and a foreground
- * camera both drawing onto the canvas, or both into the same off-screen
- * `RenderTarget` for later post-processing) composite onto one another
- * instead of each camera's clear wiping out the previous camera's draw.
- */
+    if (!spriteComponent.enabled) {
+      continue;
+    }
+
+    if (!matchesMask(spriteComponent.renderable.category, cullingMask)) {
+      continue;
+    }
+
+    const spriteEntity = spriteEntities[s];
+    const entityPosition = spritePositions[s];
+
+    pushSpriteRenderCommands(
+      commands,
+      spriteComponent,
+      entityPosition,
+      world.getComponent<RotationEcsComponent>(spriteEntity, rotationId),
+      world.getComponent<ScaleEcsComponent>(spriteEntity, scaleId),
+      world.getComponent<FlipEcsComponent>(spriteEntity, flipId),
+    );
+  }
+}
+
+function flushBatches(
+  renderContext: RenderContext,
+  projectionMatrix: Matrix3x3,
+  commands: RenderCommand[],
+): void {
+  let batchStart = 0;
+
+  for (let i = 1; i <= commands.length; i++) {
+    const isBatchBoundary =
+      i === commands.length ||
+      commands[i].renderable !== commands[batchStart].renderable;
+
+    if (isBatchBoundary) {
+      includeBatch(renderContext, projectionMatrix, commands, batchStart, i);
+      batchStart = i;
+    }
+  }
+}
+
+const commandBuffersByCameraIndex: RenderCommand[][] = [];
 const clearedDestinationsThisFrame = new Set<RenderTarget | null>();
 
 /**
  * Creates a render system that batches and renders sprites based on the camera view.
  *
- * Each camera draws into its own `CameraEcsComponent.renderTarget`, or
- * directly onto the canvas if it doesn't have one, clearing that
- * destination first (according to `RenderContext.clearStrategy`) the first
- * time it's used each frame. Cameras that share a destination (either the
- * canvas or the same `RenderTarget`) draw on top of one another rather than
- * each clearing what the last one drew.
- *
- * `run` gathers each camera's sprite commands and projection matrix without
- * drawing anything; `afterRun` does the actual drawing, once every camera
- * has run, so every camera's batches are issued from a single, predictable
- * pass over the whole tick's results.
  * @param renderContext The rendering context
  * @returns The render ECS system
  */
 export const createRenderEcsSystem = (
   renderContext: RenderContext,
-): EcsSystem<
-  [CameraEcsComponent, PositionEcsComponent],
-  void,
-  RenderPassResult
-> => ({
+): EcsSystem<[CameraEcsComponent, PositionEcsComponent]> => ({
   query: [cameraId, positionId],
-  beforeQuery: (world) => {
+  update: (world, { components: [cameras, cameraPositions] }) => {
     clearedDestinationsThisFrame.clear();
-    world.queryEntities([spriteId, positionId], spriteEntityBuffer);
-    cameraIndex = 0;
-  },
-  run: (result, world) => {
-    const [cameraComponent, positionComponent] = result.components;
 
-    const pixelsPerUnit = calculatePixelsPerUnit(
-      renderContext.height,
-      cameraComponent.verticalWorldUnits,
-    );
+    const {
+      entities: spriteEntities,
+      components: [sprites, spritePositions],
+    } = world.query<[SpriteEcsComponent, PositionEcsComponent]>([
+      spriteId,
+      positionId,
+    ]);
 
-    const projectionMatrix = createProjectionMatrix(
-      renderContext.width,
-      renderContext.height,
-      positionComponent.world,
-      cameraComponent.zoom,
-      pixelsPerUnit,
-    );
+    for (let c = 0; c < cameras.length; c++) {
+      const cameraComponent = cameras[c];
+      const cameraPositionComponent = cameraPositions[c];
 
-    let commands = commandBuffersByCameraIndex[cameraIndex];
+      const pixelsPerUnit = calculatePixelsPerUnit(
+        renderContext.height,
+        cameraComponent.verticalWorldUnits,
+      );
 
-    if (!commands) {
-      commands = [];
-      commandBuffersByCameraIndex[cameraIndex] = commands;
-    }
+      const projectionMatrix = createProjectionMatrix(
+        renderContext.width,
+        renderContext.height,
+        cameraPositionComponent.world,
+        cameraComponent.zoom,
+        pixelsPerUnit,
+      );
 
-    commands.length = 0;
-    cameraIndex += 1;
+      let commands = commandBuffersByCameraIndex[c];
 
-    for (const spriteEntity of spriteEntityBuffer) {
-      const spriteComponent = world.getComponent<SpriteEcsComponent>(
-        spriteEntity,
-        spriteId,
-      )!;
-
-      if (!spriteComponent.enabled) {
-        continue;
+      if (!commands) {
+        commands = [];
+        commandBuffersByCameraIndex[c] = commands;
       }
 
-      const { renderable } = spriteComponent;
+      commands.length = 0;
 
-      const maskMatches = matchesMask(
-        renderable.category,
+      buildCameraCommands(
+        world,
+        sprites,
+        spritePositions,
+        spriteEntities,
         cameraComponent.cullingMask,
-      );
-
-      if (!maskMatches) {
-        continue;
-      }
-
-      const entityPosition = world.getComponent<PositionEcsComponent>(
-        spriteEntity,
-        positionId,
-      )!; // Position component is guaranteed to exist due to the query in beforeQuery.
-
-      pushSpriteRenderCommands(
         commands,
-        spriteComponent,
-        entityPosition,
-        world.getComponent<RotationEcsComponent>(spriteEntity, rotationId),
-        world.getComponent<ScaleEcsComponent>(spriteEntity, scaleId),
-        world.getComponent<FlipEcsComponent>(spriteEntity, flipId),
       );
-    }
 
-    return {
-      projectionMatrix,
-      target: cameraComponent.renderTarget ?? null,
-      commands,
-      clearColor: cameraComponent.clearColor,
-    };
-  },
-  afterRun: (results) => {
-    for (const { projectionMatrix, target, commands, clearColor } of results) {
+      const target = cameraComponent.renderTarget ?? null;
+
       renderContext.bindRenderTarget(target);
 
       if (!clearedDestinationsThisFrame.has(target)) {
-        renderContext.clear(clearColor);
+        renderContext.clear(cameraComponent.clearColor);
         clearedDestinationsThisFrame.add(target);
       }
 
-      commands.sort((a, b) => {
-        if (a.layer !== b.layer) {
-          return a.layer - b.layer;
-        }
+      commands.sort((a, b) =>
+        a.layer !== b.layer ? a.layer - b.layer : a.depth - b.depth,
+      );
 
-        return a.depth - b.depth;
-      });
-
-      let batchStart = 0;
-
-      for (let i = 1; i <= commands.length; i++) {
-        const isBatchBoundary =
-          i === commands.length ||
-          commands[i].renderable !== commands[batchStart].renderable;
-
-        if (isBatchBoundary) {
-          includeBatch(
-            renderContext,
-            projectionMatrix,
-            commands,
-            batchStart,
-            i,
-          );
-          batchStart = i;
-        }
-      }
+      flushBatches(renderContext, projectionMatrix, commands);
     }
 
-    // Sprite drawing leaves blending enabled as global GL state (see
-    // `setupInstanceAttributesAndDraw`). Reset it once every camera's
-    // batches are drawn, so later systems (post-processing, presenting)
-    // start from a known, disabled baseline instead of having to assume it
-    // was left on.
     renderContext.gl.disable(renderContext.gl.BLEND);
   },
 });

--- a/src/rendering/systems/tone-map-system.test.ts
+++ b/src/rendering/systems/tone-map-system.test.ts
@@ -286,7 +286,7 @@ describe('createToneMapEcsSystem', () => {
     expect(mockGl.drawArrays).toHaveBeenCalledTimes(4);
   });
 
-  describe('cleanupEntities', () => {
+  describe('cleanup', () => {
     it('disposes the scratch target when the world stops', () => {
       const target = new RenderTarget(mockGl, 128, 128);
 

--- a/src/rendering/systems/tone-map-system.ts
+++ b/src/rendering/systems/tone-map-system.ts
@@ -34,7 +34,7 @@ import { createRenderTarget, RenderTarget } from '../render-target.js';
  */
 export const createToneMapEcsSystem = (
   renderContext: RenderContext,
-): EcsSystem<[CameraEcsComponent, ToneMappingEcsComponent], void, void> => {
+): EcsSystem<[CameraEcsComponent, ToneMappingEcsComponent]> => {
   const { gl, shaderCache } = renderContext;
 
   const toneMapMaterial = new Material(
@@ -53,7 +53,7 @@ export const createToneMapEcsSystem = (
   // and write the same texture in one draw, so the tone-mapped result is
   // written here first, then copied back into `renderTarget` (the same
   // technique `createBloomEcsSystem` uses for its composite pass). Owned by
-  // this system (not module-level state) and disposed via `cleanupEntities`
+  // this system (not module-level state) and disposed via `cleanup`
   // when the world stops.
   const scratchTargetByTarget = new WeakMap<RenderTarget, RenderTarget>();
 
@@ -98,44 +98,51 @@ export const createToneMapEcsSystem = (
 
   return {
     query: [cameraId, toneMappingId],
-    beforeQuery: () => {
+    update: (_world, { components: [cameras, toneMappings] }) => {
       processedTargetsThisFrame.clear();
-    },
-    run: (result) => {
-      const [camera, toneMapping] = result.components;
-      const { renderTarget } = camera;
 
-      if (!renderTarget || processedTargetsThisFrame.has(renderTarget)) {
-        return;
+      for (let i = 0; i < cameras.length; i++) {
+        const camera = cameras[i];
+        const toneMapping = toneMappings[i];
+        const { renderTarget } = camera;
+
+        if (!renderTarget || processedTargetsThisFrame.has(renderTarget)) {
+          continue;
+        }
+
+        processedTargetsThisFrame.add(renderTarget);
+
+        const scratchTarget = getScratchTarget(renderTarget);
+
+        beginFullscreenReplacePass(renderContext, scratchTarget);
+
+        toneMapMaterial.setUniform('u_texture', renderTarget.colorTexture);
+        toneMapMaterial.setUniform('u_exposure', toneMapping.exposure);
+        toneMapMaterial.setUniform(
+          'u_useAces',
+          toneMapping.operator === TONE_MAPPING_OPERATOR.aces,
+        );
+
+        drawFullscreenQuad(renderContext, toneMapMaterial);
+
+        copyTexture(scratchTarget.colorTexture, renderTarget);
       }
-
-      processedTargetsThisFrame.add(renderTarget);
-
-      const scratchTarget = getScratchTarget(renderTarget);
-
-      beginFullscreenReplacePass(renderContext, scratchTarget);
-
-      toneMapMaterial.setUniform('u_texture', renderTarget.colorTexture);
-      toneMapMaterial.setUniform('u_exposure', toneMapping.exposure);
-      toneMapMaterial.setUniform(
-        'u_useAces',
-        toneMapping.operator === TONE_MAPPING_OPERATOR.aces,
-      );
-
-      drawFullscreenQuad(renderContext, toneMapMaterial);
-
-      copyTexture(scratchTarget.colorTexture, renderTarget);
     },
-    cleanupEntities: (result) => {
-      const [camera] = result.components;
-      const { renderTarget } = camera;
+    cleanup: (world) => {
+      const {
+        components: [cameras],
+      } = world.query<[CameraEcsComponent]>([cameraId, toneMappingId]);
 
-      if (!renderTarget) {
-        return;
+      for (const camera of cameras) {
+        const { renderTarget } = camera;
+
+        if (!renderTarget) {
+          continue;
+        }
+
+        scratchTargetByTarget.get(renderTarget)?.dispose(gl);
+        scratchTargetByTarget.delete(renderTarget);
       }
-
-      scratchTargetByTarget.get(renderTarget)?.dispose(gl);
-      scratchTargetByTarget.delete(renderTarget);
     },
   };
 };

--- a/src/rendering/terrain/create-terrain-render-ecs-system.ts
+++ b/src/rendering/terrain/create-terrain-render-ecs-system.ts
@@ -27,35 +27,39 @@ export const createTerrainRenderEcsSystem = (
   terrainMesh: TerrainMesh,
 ): EcsSystem<[CameraEcsComponent, PositionEcsComponent]> => ({
   query: [cameraId, positionId],
-  run: (result) => {
-    const [cameraComponent, positionComponent] = result.components;
+  update: (_world, { components: [cameraComponents, positionComponents] }) => {
     const { gl } = renderContext;
     const { geometry, material, vertexCount } = terrainMesh;
 
-    renderContext.bindRenderTarget(cameraComponent.renderTarget ?? null);
+    for (let i = 0; i < cameraComponents.length; i++) {
+      const cameraComponent = cameraComponents[i];
+      const positionComponent = positionComponents[i];
 
-    const { clearColor } = cameraComponent;
+      renderContext.bindRenderTarget(cameraComponent.renderTarget ?? null);
 
-    gl.clearColor(clearColor.r, clearColor.g, clearColor.b, clearColor.a);
-    gl.clear(gl.COLOR_BUFFER_BIT);
+      const { clearColor } = cameraComponent;
 
-    const pixelsPerUnit = calculatePixelsPerUnit(
-      renderContext.height,
-      cameraComponent.verticalWorldUnits,
-    );
+      gl.clearColor(clearColor.r, clearColor.g, clearColor.b, clearColor.a);
+      gl.clear(gl.COLOR_BUFFER_BIT);
 
-    const projectionMatrix = createProjectionMatrix(
-      renderContext.width,
-      renderContext.height,
-      positionComponent.world,
-      cameraComponent.zoom,
-      pixelsPerUnit,
-    );
+      const pixelsPerUnit = calculatePixelsPerUnit(
+        renderContext.height,
+        cameraComponent.verticalWorldUnits,
+      );
 
-    material.setUniform('u_projection', projectionMatrix);
-    material.bind(gl);
-    geometry.bind(gl, material.program);
+      const projectionMatrix = createProjectionMatrix(
+        renderContext.width,
+        renderContext.height,
+        positionComponent.world,
+        cameraComponent.zoom,
+        pixelsPerUnit,
+      );
 
-    gl.drawArrays(gl.TRIANGLES, 0, vertexCount);
+      material.setUniform('u_projection', projectionMatrix);
+      material.bind(gl);
+      geometry.bind(gl, material.program);
+
+      gl.drawArrays(gl.TRIANGLES, 0, vertexCount);
+    }
   },
 });

--- a/src/timer/systems/timer-system.ts
+++ b/src/timer/systems/timer-system.ts
@@ -1,6 +1,5 @@
 import { Time } from '../../common/index.js';
 import { TimerEcsComponent, TimerId } from '../components/timer-component.js';
-
 import { EcsSystem } from '../../ecs/ecs-system.js';
 
 /**
@@ -11,38 +10,36 @@ export const createTimerEcsSystem = (
   time: Time,
 ): EcsSystem<[TimerEcsComponent]> => ({
   query: [TimerId],
-  run: (result) => {
-    const [timerComponent] = result.components;
+  update: (_world, { components: [timerComponents] }) => {
+    const deltaTime = time.deltaTimeInMilliseconds;
 
-    if (timerComponent.tasks.length === 0) {
-      return;
-    }
+    for (let c = 0; c < timerComponents.length; c++) {
+      const timerComponent = timerComponents[c];
+      const tasks = timerComponent.tasks;
 
-    // Iterate backwards to safely remove tasks as needed
-    for (let i = timerComponent.tasks.length - 1; i >= 0; i--) {
-      const task = timerComponent.tasks[i];
-      task.elapsed += time.deltaTimeInMilliseconds;
+      if (tasks.length === 0) {
+        continue;
+      }
 
-      if (task.elapsed >= task.delay) {
-        task.callback();
+      for (let i = tasks.length - 1; i >= 0; i--) {
+        const task = tasks[i];
+        task.elapsed += deltaTime;
 
-        if (task.repeat && task.interval !== undefined) {
-          // Periodic task
-          task.runsSoFar!++;
+        if (task.elapsed >= task.delay) {
+          task.callback();
 
-          if (task.maxRuns !== undefined && task.runsSoFar! >= task.maxRuns) {
-            // Remove if we have run it the max times
-            timerComponent.tasks.splice(i, 1);
+          if (task.repeat && task.interval !== undefined) {
+            task.runsSoFar = (task.runsSoFar ?? 0) + 1;
+
+            if (task.maxRuns !== undefined && task.runsSoFar >= task.maxRuns) {
+              tasks.splice(i, 1);
+            } else {
+              task.elapsed = 0;
+              task.delay = task.interval;
+            }
           } else {
-            // Reset elapsed for the next interval
-            task.elapsed = 0;
-            // Now that the first run is done, subsequent intervals
-            // are determined by 'interval' rather than 'delay'.
-            task.delay = task.interval;
+            tasks.splice(i, 1);
           }
-        } else {
-          // One-shot task, remove after execution
-          timerComponent.tasks.splice(i, 1);
         }
       }
     }

--- a/src/timer/systems/timer-system.ts
+++ b/src/timer/systems/timer-system.ts
@@ -2,6 +2,8 @@ import { Time } from '../../common/index.js';
 import { TimerEcsComponent, TimerId } from '../components/timer-component.js';
 import { EcsSystem } from '../../ecs/ecs-system.js';
 
+type TimerTask = TimerEcsComponent['tasks'][number];
+
 /**
  * Creates an ECS system to handle timers.
  * @param time - The time instance used to advance each timer's elapsed time.
@@ -13,35 +15,47 @@ export const createTimerEcsSystem = (
   update: (_world, { components: [timerComponents] }) => {
     const deltaTime = time.deltaTimeInMilliseconds;
 
-    for (let c = 0; c < timerComponents.length; c++) {
-      const timerComponent = timerComponents[c];
-      const tasks = timerComponent.tasks;
-
-      if (tasks.length === 0) {
-        continue;
-      }
-
-      for (let i = tasks.length - 1; i >= 0; i--) {
-        const task = tasks[i];
-        task.elapsed += deltaTime;
-
-        if (task.elapsed >= task.delay) {
-          task.callback();
-
-          if (task.repeat && task.interval !== undefined) {
-            task.runsSoFar = (task.runsSoFar ?? 0) + 1;
-
-            if (task.maxRuns !== undefined && task.runsSoFar >= task.maxRuns) {
-              tasks.splice(i, 1);
-            } else {
-              task.elapsed = 0;
-              task.delay = task.interval;
-            }
-          } else {
-            tasks.splice(i, 1);
-          }
-        }
-      }
+    for (let i = 0; i < timerComponents.length; i++) {
+      advanceTimerTasks(timerComponents[i].tasks, deltaTime);
     }
   },
 });
+
+const advanceTimerTasks = (tasks: TimerTask[], deltaTime: number) => {
+  for (let i = tasks.length - 1; i >= 0; i--) {
+    const task = tasks[i];
+
+    if (!advanceTimerTask(task, deltaTime)) {
+      continue;
+    }
+
+    task.callback();
+
+    if (shouldRemoveTimerTask(task)) {
+      tasks.splice(i, 1);
+    } else {
+      resetRepeatingTimerTask(task);
+    }
+  }
+};
+
+const advanceTimerTask = (task: TimerTask, deltaTime: number) => {
+  task.elapsed += deltaTime;
+
+  return task.elapsed >= task.delay;
+};
+
+const shouldRemoveTimerTask = (task: TimerTask) => {
+  if (!task.repeat || task.interval === undefined) {
+    return true;
+  }
+
+  task.runsSoFar = (task.runsSoFar ?? 0) + 1;
+
+  return task.maxRuns !== undefined && task.runsSoFar >= task.maxRuns;
+};
+
+const resetRepeatingTimerTask = (task: TimerTask) => {
+  task.elapsed = 0;
+  task.delay = task.interval ?? 0;
+};


### PR DESCRIPTION
## Summary

Finishes the `EcsSystem` interface refactor that was started in this branch's earlier commits (`refactor: streamline ECS system and world interfaces...`, plus the timer/age-scale-system/render-system follow-ups). That change replaced the old per-entity `run(queryResult, world, beforeQueryResult)` dispatch — with its `beforeQuery`/`afterRun`/`cleanupEntities`/`cleanupSystem` hooks — with a single batched `update(world, queryResult)` call per tick (`queryResult.entities` + one `components` array per queried component type) and a single `cleanup(world)` hook. This PR migrates every remaining consumer of the old contract:

- **`src/ecs`**: fixed `ecs-world.ts` import paths left without `.js` extensions by the in-progress refactor, and rewrote `ecs-world.test.ts` for the new `update`/`cleanup` contract.
- **All remaining `/src` systems** (animations, audio, input, lifecycle, particles, physics, rendering post-processing/terrain) and their tests. Physics registration systems (`physics-sync`, `prismatic-joint`, `revolute-joint`) now register bodies/joints directly in `update` instead of `beforeQuery`, and release them in `cleanup` by iterating what they themselves registered (since `cleanup` no longer receives per-entity query results). Post-processing systems (`bloom`, `gaussian-blur`, `tone-map`) fold `beforeQuery`+`run` into `update`, and re-query the world in `cleanup`.
- **`/e2e` input scene fixtures**: the keyboard/mouse/gamepad scenes' input-consumer systems no longer need to anchor themselves on the camera entity to run exactly once per tick — `update` already does that.
- **`documentation-site/src/pages/demos`**: every demo's custom `EcsSystem` migrated to match.
- **Docs**: rewrote `documentation-site/docs/docs/ecs/system.md` and `world.md`, plus every other guide with a system code example (math, input, events docs), to describe `update`/`cleanup` instead of the removed hooks. Also updated `AGENTS.md`'s ECS architecture and System Pattern sections, which had been describing a stale class-based `System`/`Entity` API predating even the old batched contract.

## Notable behavior change

`EcsWorld.removeSystem` and `EcsWorld.stop` now both invoke the same `cleanup` hook (previously `removeSystem` only ran `cleanupSystem`, while `stop` ran `cleanupEntities` then `cleanupSystem`). Updated the three physics tests that asserted on the old split behavior (`physics-sync`, `prismatic-joint`, `revolute-joint` "should stop reacting to entity removal..." tests) to assert that `removeSystem` now releases registered resources immediately.

## Test plan

- [x] `npm run check-types` — 0 errors
- [x] `npm test` — 1065 tests passing
- [x] `npm run lint` — 0 errors
- [x] `npm run cspell` — 0 issues
- [x] `npm run check-exports` — passes
- [x] `npm run check-types:e2e` — 0 errors
- [x] `documentation-site`: `npm run typecheck` and `npm run build` — both pass
- [x] Started the docs site (`npm run start`) and loaded all 16 touched demo pages in a real (Playwright-driven) browser — every one rendered correctly with no console/page exceptions; also drove real keyboard input in the `rolling-ball` demo to confirm the migrated physics/camera-follow/terrain-render systems respond correctly at runtime, not just on the first frame.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FQi31j1gvZT25n6PjaR5YR)_