### PR TITLE
feat(physics): add explicit static/kinematic/dynamic rigid body typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - **physics:** Add `raycast(world, start, end, sort?)`, casting a line segment against every entity in an `EcsWorld` with a `ColliderEcsComponent` (`CircleCollider`, `PolygonCollider`, and `TerrainCollider` alike) and returning every intersection as a `RaycastHit` (`entity`, `point`, `normal`, `distance`), ordered by distance from `start` by default
+- **physics:** Add `RigidBodyEcsComponent.type` (`'dynamic'` | `'kinematic'` | `'static'`, defaulting to `'dynamic'`), letting a body be moved directly by game code (`'kinematic'`) so it still pushes dynamic bodies on contact without itself being affected by gravity, forces, or impulses - previously only possible implicitly, by giving an entity no `RigidBodyEcsComponent` at all (still supported, and equivalent to `type: 'static'`)
 
 #### Changed
 

--- a/documentation-site/docs/docs/physics/index.md
+++ b/documentation-site/docs/docs/physics/index.md
@@ -3,27 +3,29 @@
 Forge includes a native 2D physics engine: rigid bodies, convex collision
 shapes, gravity, collision detection and resolution, raycasting, and
 impulse-based forces (including explosions). It has no external
-dependencies and integrates with the ECS via `createPhysicsSyncEcsSystem`, which
-steps a `PhysicsWorld` every frame and keeps `RigidBody` transforms in sync
-with entity position/rotation components.
+dependencies and is entirely ECS-native - there's no separate physics world
+object to step; each concern (gravity, broad phase, narrow phase, collision
+resolution, integration, joints) is its own system, registered on the
+`EcsWorld` like any other.
 
 Core concepts:
 
-- `PhysicsWorld`: owns the set of
-  simulated bodies, steps the simulation, and applies world-level forces
-  (gravity, explosions).
-- `RigidBody`: a simulated body with a
-  position, velocity, mass, and a collision shape.
-- `CircleShape` and
-  `PolygonShape`: the convex shapes a
-  `RigidBody` can have.
-- `TerrainShape`: a static heightmap
-  ground shape for non-convex 2D terrain.
+- `RigidBodyEcsComponent`: a
+  simulated body's velocity, mass, and `type` (`'dynamic'`, `'kinematic'`,
+  or `'static'`).
+- `ColliderEcsComponent`: an entity's
+  collision shape (`CircleCollider`,
+  `PolygonCollider`, or
+  `TerrainCollider`), plus friction and
+  restitution.
+- `createBroadPhaseEcsSystem`/`createNarrowPhaseEcsSystem`/
+  `createCollisionResolutionEcsSystem`: detect and resolve collisions
+  between collider entities each tick.
 - `raycast`: casts a ray against every
   collider entity in an `EcsWorld`.
-- `PrismaticJoint`: a slider
-  constraint locking two bodies to one linear degree of freedom.
-- `RevoluteJoint`: a hinge
+- `PrismaticJointEcsComponent`: a
+  slider constraint locking two bodies to one linear degree of freedom.
+- `RevoluteJointEcsComponent`: a hinge
   constraint locking two bodies to one rotational degree of freedom about a
   shared anchor point.
 - `LinearSpringEcsComponent`
@@ -34,8 +36,8 @@ Core concepts:
 
 Guides in this section:
 
-- [Bodies and Shapes](./rigid-bodies.md): creating bodies and shapes, ECS
-  integration, and collision events.
+- [Bodies and Shapes](./rigid-bodies.md): creating bodies and shapes,
+  static/kinematic/dynamic bodies, and ECS integration.
 - [Applying Forces](./forces.md): gravity, impulses, torque, springs and
   dampers, and explosions.
 - [Raycasting](./raycasting.md): casting rays against colliders.
@@ -48,43 +50,65 @@ Guides in this section:
 
 ## Quick Start
 
-The simplest way to use physics is through the ECS integration: give an
-entity a `PhysicsBodyEcsComponent` alongside its position and rotation
-components, then register `createPhysicsSyncEcsSystem`. Every `world.update()`,
-the system steps the `PhysicsWorld` and writes each dynamic body's resulting
-position and angle back to the entity.
+Give an entity a `ColliderEcsComponent` and a `RigidBodyEcsComponent`
+alongside its position and rotation components, then register the systems
+that simulate them. Every `world.update()`, those systems apply gravity,
+detect and resolve collisions, and integrate each dynamic (or kinematic)
+body's velocity into its position/rotation.
 
 ```ts
 import { addPositionComponent, addRotationComponent } from '@forge-game-engine/forge/common';
-import { Vec2 } from '@forge-game-engine/forge/math';
 import {
-  addPhysicsBodyComponent,
-  createPhysicsSyncEcsSystem,
-  PhysicsWorld,
-  PolygonShape,
-  RigidBody,
+  addAabbComponent,
+  addColliderComponent,
+  addGravityComponent,
+  addRigidBodyComponent,
+  CollisionManifold,
+  CollisionPair,
+  ContactConstraint,
+  createBroadPhaseEcsSystem,
+  createCollisionResolutionEcsSystem,
+  createEulerIntegrationEcsSystem,
+  createGravityEcsSystem,
+  createNarrowPhaseEcsSystem,
+  PolygonCollider,
 } from '@forge-game-engine/forge/physics';
 import { createGame } from '@forge-game-engine/forge/utilities';
 
 const { world, time } = createGame('game-container');
 
-const physicsWorld = new PhysicsWorld({ gravity: { x: 0, y: -300 } });
-
 const box = world.createEntity();
+// PolygonCollider re-centers vertices around their centroid, so this 32x32
+// square's own position is its center.
+const collider = new PolygonCollider([
+  { x: -16, y: -16 },
+  { x: 16, y: -16 },
+  { x: 16, y: 16 },
+  { x: -16, y: 16 },
+]);
 
 addPositionComponent(world, box);
 addRotationComponent(world, box);
-addPhysicsBodyComponent(world, box, {
-  physicsBody: new RigidBody({ shape: PolygonShape.rectangle(32, 32) }),
+addColliderComponent(world, box, { collider });
+addAabbComponent(world, box);
+addRigidBodyComponent(world, box, {
+  mass: collider.mass,
+  momentOfInertia: collider.momentOfInertia,
 });
+addGravityComponent(world, box, { amount: { x: 0, y: -300 } });
 
-world.addSystem(createPhysicsSyncEcsSystem(physicsWorld, time));
+const collisionPairs: CollisionPair[] = [];
+const collisionManifolds: CollisionManifold[] = [];
+const contactConstraints: ContactConstraint[] = [];
+
+world.addSystem(createGravityEcsSystem(time));
+world.addSystem(createBroadPhaseEcsSystem(collisionPairs));
+world.addSystem(createNarrowPhaseEcsSystem(collisionPairs, collisionManifolds));
+world.addSystem(
+  createCollisionResolutionEcsSystem(collisionManifolds, contactConstraints, time),
+);
+world.addSystem(createEulerIntegrationEcsSystem(time));
 ```
 
-See [Bodies and Shapes](./rigid-bodies.md#ecs-integration) for static and
-kinematic bodies, and how a body's transform maps onto
-`PositionEcsComponent`/`RotationEcsComponent`.
-
-You can also use `PhysicsWorld` and `RigidBody` directly, without the ECS, by
-calling `physicsWorld.addBody(body)` and `physicsWorld.step(deltaTimeInSeconds)`
-yourself each frame.
+See [Bodies and Shapes](./rigid-bodies.md) for static and kinematic bodies,
+choosing a collision shape, and the full system registration order.

--- a/documentation-site/docs/docs/physics/rigid-bodies.md
+++ b/documentation-site/docs/docs/physics/rigid-bodies.md
@@ -4,147 +4,177 @@ sidebar_position: 1
 
 # Bodies and Shapes
 
-A `RigidBody` pairs a transform
-(position, angle, velocity) with a collision shape. For the full set of
-constructor options and properties, see
-`RigidBody` and
-`RigidBodyOptions` in the API
-reference. This page covers the choices that aren't obvious from the options
-list: which shape to use, what `isStatic`/`isSensor`/`isKinematic` actually
-do, and how to get back from a collision to the ECS entity that caused it.
+A simulated body is an entity with a `ColliderEcsComponent` (a shape) plus,
+for anything that isn't static, a `RigidBodyEcsComponent` (mass, velocity,
+and how it participates in the simulation). Both sit alongside the entity's
+`PositionEcsComponent`/`RotationEcsComponent` and an `AabbEcsComponent` used
+for broad-phase culling. This page covers the choices that aren't obvious
+from the component options: which collider shape to use, static vs.
+kinematic vs. dynamic bodies, and how to wire up the systems that actually
+simulate them.
 
 ```ts
+import { addPositionComponent, addRotationComponent } from '@forge-game-engine/forge/common';
+import {
+  addAabbComponent,
+  addColliderComponent,
+  addRigidBodyComponent,
+  CircleCollider,
+} from '@forge-game-engine/forge/physics';
 import { Vec2 } from '@forge-game-engine/forge/math';
-import { CircleShape, RigidBody } from '@forge-game-engine/forge/physics';
 
-const ball = new RigidBody({
-  shape: new CircleShape(16),
-  position: { x: 0, y: 100 },
+const ball = world.createEntity();
+const collider = new CircleCollider(16);
+
+addPositionComponent(world, ball, { world: { x: 0, y: 100 } });
+addRotationComponent(world, ball);
+addColliderComponent(world, ball, {
+  collider,
   restitution: 0.6,
   friction: 0.4,
+});
+addAabbComponent(world, ball);
+addRigidBodyComponent(world, ball, {
+  mass: collider.mass,
+  momentOfInertia: collider.momentOfInertia,
 });
 ```
 
 ## Choosing a shape
 
-Use `CircleShape` for anything round.
-Its area, bounding radius, and moment of inertia are all closed-form, and
-circle-circle/circle-polygon collision checks are the cheapest narrow-phase
-tests in the engine.
+Use `CircleCollider` for anything round. Its area, bounding radius, and
+moment of inertia are all closed-form, and circle-circle/circle-polygon
+collision checks are the cheapest narrow-phase tests in the engine.
 
-Use `PolygonShape` for everything
-else, including the `rectangle(width, height)` static helper for boxes.
-
-:::caution
-`PolygonShape` requires at least 3 vertices forming a **convex** polygon, and
-throws otherwise. If you need a concave shape, such as an L-shape, decompose
-it into multiple convex `PolygonShape`s on separate bodies rather than
-trying to pass the concave outline directly.
-:::
-
-## Static, dynamic, sensor, and kinematic bodies
-
-Most of the time spent configuring a body goes into deciding how it should
-participate in the simulation:
-
-- **Dynamic** (the default): gravity, collisions, and impulses all affect
-  it. Use this for anything that should move and react physically, such as
-  crates, characters, and projectiles.
-- **Static** (`isStatic: true`): infinite mass, never moves. Use this for
-  floors, walls, and other immovable geometry. A pair of two static bodies
-  never produces collision events, since neither side can move.
-- **Sensor** (`isSensor: true`): still participates in collision _detection_
-  (and so still raises `collisionStarts`/`collisionEnds`), but produces no
-  impulses or positional correction. Use this for trigger volumes, such as
-  pickups, checkpoints, and damage zones, where you want to know that
-  something overlapped without physically blocking it.
-- **Kinematic** (ECS only: `isKinematic: true` on `PhysicsBodyEcsComponent`
-  with `isStatic: false`): like static, the entity's position/rotation drive
-  the body every frame, but unlike static, it still participates in
-  collision detection against non-static bodies. Use this for moving
-  platforms or scripted actors whose motion is driven by another system but
-  that still need to raise collision events.
+Use `PolygonCollider` for everything else, including straight-edged shapes
+built from raw vertices (see `_spawn-shapes.ts`'s `rectangleVertices` in the
+[Physics demo](/Forge/demos/physics) for a boxes-and-triangles example). For
+non-convex ground built from a heightmap, use `TerrainCollider` instead - see
+[Terrain](./terrain.md).
 
 :::caution
-A sensor that needs to detect overlaps with a static body (for example, a
-pressure plate built into a wall) won't work if both bodies are static,
-since the pair never generates an event. Make the sensor `isKinematic: true`
-instead of `isStatic: true` if its position is externally controlled.
+`PolygonCollider` requires at least 3 vertices forming a **convex** polygon,
+and throws otherwise. If you need a concave shape, such as an L-shape,
+decompose it into multiple convex `PolygonCollider`s on separate entities
+rather than trying to pass the concave outline directly.
 :::
 
-## ECS Integration
+A collider's `mass`/`momentOfInertia` are computed from its shape (and, for
+`CircleCollider`, an optional `density`) - pass them straight into
+`addRigidBodyComponent` as shown above, rather than picking mass values by
+hand.
 
-Add a `PhysicsBodyEcsComponent`, keyed by
-`PhysicsBodyId`, alongside
-`PositionEcsComponent` and `RotationEcsComponent`, then register
-`createPhysicsSyncEcsSystem``(physicsWorld, time)`.
-See `PhysicsBodyEcsComponent`
-for the full component shape.
+## Static, kinematic, and dynamic bodies
+
+`RigidBodyEcsComponent.type` (`'dynamic'`, `'kinematic'`, or `'static'`,
+defaulting to `'dynamic'`) controls how a body participates in the
+simulation:
+
+- **Dynamic** (the default): gravity (via `GravityEcsComponent`), impulses,
+  and collisions all affect it, and `createEulerIntegrationEcsSystem`
+  integrates its `velocity`/`angularVelocity` into position/rotation every
+  tick. Use this for anything that should move and react physically, such
+  as crates, characters, and projectiles.
+- **Static**: infinite effective mass, never affected by anything, never
+  integrated. The simplest way to make a body static is to give its entity
+  a `ColliderEcsComponent` (plus `PositionEcsComponent`/
+  `RotationEcsComponent`/`AabbEcsComponent`) and **no**
+  `RigidBodyEcsComponent` at all - every static entity in the physics demos
+  (floors, walls, `TerrainCollider` ground) follows this convention, and it
+  still applies unchanged. Attaching a `RigidBodyEcsComponent` with
+  `type: 'static'` behaves identically; only do so when something else on
+  the entity (a motor, a joint) requires the component to be present.
+- **Kinematic**: driven directly by your own code, most commonly by setting
+  `velocity` (and letting `createEulerIntegrationEcsSystem` move it) or by
+  writing to `PositionEcsComponent`/`RotationEcsComponent` yourself. Like a
+  static body, it's never affected by gravity, forces, or collision/joint
+  impulses (its effective mass is infinite to the solver), but unlike a
+  static body it's still integrated every tick and its velocity still shows
+  up in contact/joint solving, so it correctly pushes any dynamic body it
+  touches. Use this for moving platforms and other scripted movers that
+  dynamic bodies should react to.
 
 ```ts
-import { addPositionComponent, addRotationComponent } from '@forge-game-engine/forge/common';
-import {
-  addPhysicsBodyComponent,
-  CircleShape,
-  RigidBody,
-} from '@forge-game-engine/forge/physics';
-import { Vec2 } from '@forge-game-engine/forge/math';
+import { addRigidBodyComponent } from '@forge-game-engine/forge/physics';
 
-const entity = world.createEntity();
-
-addPositionComponent(world, entity, {
-  world: { x: 0, y: 100 },
-  local: { x: 0, y: 100 },
-});
-addRotationComponent(world, entity);
-addPhysicsBodyComponent(world, entity, {
-  physicsBody: new RigidBody({ shape: new CircleShape(16) }),
+// A moving platform: velocity is set once (or updated by your own game
+// code), and createEulerIntegrationEcsSystem moves it every tick from
+// there. Dynamic bodies standing on it get carried along and pushed by it,
+// but nothing (gravity included) ever changes the platform's own velocity.
+addRigidBodyComponent(world, platformEntity, {
+  mass: platformCollider.mass,
+  momentOfInertia: platformCollider.momentOfInertia,
+  type: 'kinematic',
+  velocity: { x: 40, y: 0 },
 });
 ```
 
-The system registers each body with `physicsWorld` the first time its entity
-is queried, removes it when the entity stops matching (or is removed), and
-sets `physicsBody.userData` to the entity id, which is how you map
-collisions back to entities below.
-
-:::caution[Coordinate spaces]
-`RotationEcsComponent.world` is in render space (Y-down), while
-`RigidBody.angle` is in physics world space (Y-up). The two are mirrored, so
-the angle is negated whenever it crosses between the ECS and the physics
-simulation. If you read or write `physicsBody.angle` directly, remember it's
-the negation of the entity's render-space rotation, not the same value.
+:::caution
+A `'kinematic'` body still needs `mass`/`momentOfInertia` values to satisfy
+`RigidBodyEcsComponent`'s required options, even though they're never used
+by the solver (its effective mass is always treated as infinite). Pass its
+collider's `mass`/`momentOfInertia` the same as for a dynamic body.
 :::
+
+## ECS integration
+
+There's no single "physics world" object to step - each concern is its own
+system, registered on the `EcsWorld` alongside your other systems. A typical
+setup (see the [Physics demo](/Forge/demos/physics)'s `_create-game.ts` for
+the full, working version):
+
+```ts
+import { Time } from '@forge-game-engine/forge/common';
+import {
+  CollisionManifold,
+  CollisionPair,
+  ContactConstraint,
+  createBroadPhaseEcsSystem,
+  createCollisionResolutionEcsSystem,
+  createEulerIntegrationEcsSystem,
+  createGravityEcsSystem,
+  createNarrowPhaseEcsSystem,
+} from '@forge-game-engine/forge/physics';
+
+const collisionPairs: CollisionPair[] = [];
+const collisionManifolds: CollisionManifold[] = [];
+const contactConstraints: ContactConstraint[] = [];
+
+// Order matters: gravity/forces before collision resolution, before
+// integration, so each tick's forces are reflected in that same tick's
+// position update.
+world.addSystem(createGravityEcsSystem(time));
+world.addSystem(createBroadPhaseEcsSystem(collisionPairs));
+world.addSystem(createNarrowPhaseEcsSystem(collisionPairs, collisionManifolds));
+world.addSystem(
+  createCollisionResolutionEcsSystem(collisionManifolds, contactConstraints, time),
+);
+world.addSystem(createEulerIntegrationEcsSystem(time));
+```
+
+Add joint (`createRevoluteJointEcsSystem`/`createPrismaticJointEcsSystem`)
+and force-generator (`createLinearSpringEcsSystem`/
+`createLinearDamperEcsSystem`) systems the same way; see
+[Applying Forces](./forces.md), [Prismatic Joints](./joints.md), and
+[Revolute Joints](./revolute-joints.md) for their registration order
+relative to the systems above.
 
 ## Mapping collisions back to entities
 
-After each step (handled for you by `createPhysicsSyncEcsSystem`),
-`collisionStarts`/`collisionEnds`
-list the body pairs that started or stopped touching. Since
-`createPhysicsSyncEcsSystem` sets `body.userData` to the entity id, you can
-recover the ECS entities involved:
+Because everything is ECS-native, there's no separate body object or
+`userData` mapping to bridge: `collisionManifolds` (populated by
+`createNarrowPhaseEcsSystem`) already holds the raw `entityA`/`entityB`
+entity ids for every confirmed collision each tick.
 
 ```ts
-for (const { bodyA, bodyB } of physicsWorld.collisionStarts) {
-  const entityA = bodyA.userData as number;
-  const entityB = bodyB.userData as number;
-
-  // check tags/components on entityA and entityB to award a pickup,
-  // apply damage, play a sound, etc.
+for (const manifold of collisionManifolds) {
+  // check tags/components on manifold.entityA and manifold.entityB to
+  // award a pickup, apply damage, play a sound, etc.
 }
 ```
 
-## Performance: cached bounding boxes and world-space geometry
-
-`RigidBody.aabb` and `PolygonShape.getWorldVertices`/`getWorldNormals` are
-recomputed only when the body's position or angle has changed since the last
-call (compared by value, so mutating `position.x` in place still invalidates
-the cache correctly). Reading them repeatedly within the same frame, as the
-broad- and narrow-phase collision detector does, is essentially free.
-
-:::caution
-The cached result is returned by reference, not copied. Treat the value
-returned from `aabb`, `getWorldVertices`, and `getWorldNormals` as read-only.
-Mutating it in place, for example `body.aabb.origin.x += 1`, corrupts the
-cached value for every later call until the body's position or angle next
-changes.
-:::
+Read `collisionManifolds` after `createCollisionResolutionEcsSystem` has run
+(later in the same tick, or at the start of the next one) if you need it to
+reflect this tick's resolved contacts; the array is cleared and refilled by
+`createNarrowPhaseEcsSystem` every tick, so hold onto anything you need
+before that system runs again.

--- a/documentation-site/docs/docs/physics/rigid-bodies.md
+++ b/documentation-site/docs/docs/physics/rigid-bodies.md
@@ -92,7 +92,8 @@ simulation:
   static body it's still integrated every tick and its velocity still shows
   up in contact/joint solving, so it correctly pushes any dynamic body it
   touches. Use this for moving platforms and other scripted movers that
-  dynamic bodies should react to.
+  dynamic bodies should react to. See the
+  [Moving Platform demo](/Forge/demos/moving-platform) for a working example.
 
 ```ts
 import { addRigidBodyComponent } from '@forge-game-engine/forge/physics';

--- a/documentation-site/docs/docs/physics/terrain.md
+++ b/documentation-site/docs/docs/physics/terrain.md
@@ -41,7 +41,7 @@ Terrain is static, so `groundEntity` only needs `PositionEcsComponent`/
 `ColliderEcsComponent`, and `AabbEcsComponent` - no `RigidBodyEcsComponent`,
 the same convention every other static body (walls, ground boxes) in this
 engine follows. See the [Bodies and Shapes guide](/Forge/docs/docs/physics/rigid-bodies)
-for that static-vs-dynamic distinction.
+for that static/kinematic/dynamic distinction.
 
 ## Authoring points
 

--- a/documentation-site/docusaurus.config.ts
+++ b/documentation-site/docusaurus.config.ts
@@ -132,6 +132,10 @@ const config: Config = {
               label: 'Physics',
             },
             {
+              to: 'demos/moving-platform',
+              label: 'Moving Platform',
+            },
+            {
               to: 'demos/raycasting',
               label: 'Raycasting',
             },

--- a/documentation-site/src/pages/demos/moving-platform/_create-boundaries.ts
+++ b/documentation-site/src/pages/demos/moving-platform/_create-boundaries.ts
@@ -1,0 +1,104 @@
+import { EcsWorld } from '@forge-game-engine/forge/ecs';
+import {
+  addPositionComponent,
+  addRotationComponent,
+} from '@forge-game-engine/forge/common';
+import { Vec2, Vector2 } from '@forge-game-engine/forge/math';
+import {
+  addAabbComponent,
+  addColliderComponent,
+  PolygonCollider,
+} from '@forge-game-engine/forge/physics';
+import {
+  addSpriteComponent,
+  calculateVisibleWorldSize,
+  createImageSprite,
+  RenderContext,
+} from '@forge-game-engine/forge/rendering';
+import { DEMO_VERTICAL_WORLD_UNITS } from '@site/src/utils/demo-camera';
+import { getAssetUrl } from '@site/src/utils/get-asset-url';
+
+export const wallThickness = 40;
+
+function rectangleVertices(width: number, height: number): Vector2[] {
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+
+  return [
+    { x: -halfWidth, y: -halfHeight },
+    { x: halfWidth, y: -halfHeight },
+    { x: halfWidth, y: halfHeight },
+    { x: -halfWidth, y: halfHeight },
+  ];
+}
+
+/**
+ * Creates static, non-rigid-body entities for the floor and side walls: a
+ * safety net that catches any crate that slides off the platform's edge,
+ * and keeps everything within the visible area.
+ * @param world - The ECS world to add the boundary entities to.
+ * @param renderContext - The render context used to load the wall sprite.
+ * @param renderLayer - The render layer the boundaries should be drawn on.
+ */
+export async function createBoundaries(
+  world: EcsWorld,
+  renderContext: RenderContext,
+  renderLayer: number,
+): Promise<void> {
+  const wallImage = await renderContext.imageCache.getOrLoad(
+    getAssetUrl('img/White.png'),
+  );
+  const wallSprite = createImageSprite(wallImage, renderContext, renderLayer);
+
+  const { x: width, y: height } = calculateVisibleWorldSize(
+    renderContext.width,
+    renderContext.height,
+    DEMO_VERTICAL_WORLD_UNITS,
+  );
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+
+  const createWall = (
+    position: Vector2,
+    wallWidth: number,
+    wallHeight: number,
+  ): void => {
+    const entity = world.createEntity();
+
+    addPositionComponent(world, entity, {
+      world: Vec2.clone(position),
+      local: Vec2.clone(position),
+    });
+
+    addRotationComponent(world, entity);
+
+    addSpriteComponent(world, entity, {
+      ...wallSprite,
+      width: wallWidth,
+      height: wallHeight,
+    });
+
+    addColliderComponent(world, entity, {
+      collider: new PolygonCollider(rectangleVertices(wallWidth, wallHeight)),
+    });
+    addAabbComponent(world, entity);
+  };
+
+  createWall(
+    { x: 0, y: -halfHeight + wallThickness / 2 },
+    width,
+    wallThickness,
+  );
+
+  createWall(
+    { x: -halfWidth + wallThickness / 2, y: 0 },
+    wallThickness,
+    height,
+  );
+
+  createWall(
+    { x: halfWidth - wallThickness / 2, y: 0 },
+    wallThickness,
+    height,
+  );
+}

--- a/documentation-site/src/pages/demos/moving-platform/_create-game.ts
+++ b/documentation-site/src/pages/demos/moving-platform/_create-game.ts
@@ -1,0 +1,131 @@
+import {
+  calculatePixelsPerUnit,
+  calculateVisibleWorldSize,
+  createCamera,
+  createCameraEcsSystem,
+  createRenderEcsSystem,
+  screenToWorldSpace,
+} from '@forge-game-engine/forge/rendering';
+import { createGame, Game } from '@forge-game-engine/forge/utilities';
+import {
+  CollisionManifold,
+  CollisionPair,
+  ContactConstraint,
+  createBroadPhaseEcsSystem,
+  createCollisionResolutionEcsSystem,
+  createEulerIntegrationEcsSystem,
+  createGravityEcsSystem,
+  createNarrowPhaseEcsSystem,
+} from '@forge-game-engine/forge/physics';
+import { Vec2 } from '@forge-game-engine/forge/math';
+import { DEMO_VERTICAL_WORLD_UNITS } from '@site/src/utils/demo-camera';
+import { createBoundaries } from './_create-boundaries';
+import { createPlatform, platformHeight } from './_create-platform';
+import { createPlatformMoverEcsSystem } from './_platform-mover.system';
+import { crateSize, loadCrateSprite, spawnCrate } from './_spawn-crates';
+
+const renderLayers = {
+  foreground: 1 << 0,
+};
+
+export const createMovingPlatformGame = async (): Promise<Game> => {
+  const { game, world, renderContext, time } = createGame('demo-game');
+
+  createCamera(world, {
+    isStatic: true,
+    cullingMask: renderLayers.foreground,
+    verticalWorldUnits: DEMO_VERTICAL_WORLD_UNITS,
+  });
+
+  const { x: width, y: height } = calculateVisibleWorldSize(
+    renderContext.width,
+    renderContext.height,
+    DEMO_VERTICAL_WORLD_UNITS,
+  );
+  const platformY = -height * 0.15;
+  const leftX = -width * 0.25;
+  const rightX = width * 0.25;
+
+  await createBoundaries(world, renderContext, renderLayers.foreground);
+  await createPlatform(
+    world,
+    renderContext,
+    renderLayers.foreground,
+    leftX,
+    rightX,
+    platformY,
+  );
+
+  const crateSprite = await loadCrateSprite(
+    renderContext,
+    renderLayers.foreground,
+  );
+
+  // A small starting stack above the platform's initial (leftmost) position,
+  // so it's immediately obvious the platform carries whatever lands on it.
+  const platformSurfaceY = platformY + platformHeight / 2 + crateSize / 2 + 8;
+
+  for (let i = 0; i < 3; i++) {
+    spawnCrate(world, crateSprite, {
+      x: leftX + (i - 1) * (crateSize + 4),
+      y: platformSurfaceY + i * (crateSize + 4),
+    });
+  }
+
+  const collisionPairs: CollisionPair[] = [];
+  const collisionManifolds: CollisionManifold[] = [];
+  const contactConstraints: ContactConstraint[] = [];
+
+  // Gravity and the platform's own mover must run before collision
+  // resolution, so this tick's velocity changes are reflected in the
+  // solver; euler integration runs last so it moves every body (dynamic
+  // crates and the kinematic platform alike) from this tick's resolved
+  // velocity.
+  world.addSystem(createGravityEcsSystem(time));
+  world.addSystem(createPlatformMoverEcsSystem());
+  world.addSystem(createBroadPhaseEcsSystem(collisionPairs));
+  world.addSystem(
+    createNarrowPhaseEcsSystem(collisionPairs, collisionManifolds),
+  );
+  world.addSystem(
+    createCollisionResolutionEcsSystem(
+      collisionManifolds,
+      contactConstraints,
+      time,
+    ),
+  );
+  world.addSystem(createCameraEcsSystem(time));
+  world.addSystem(createRenderEcsSystem(renderContext));
+  world.addSystem(createEulerIntegrationEcsSystem(time));
+
+  // Click anywhere to drop another crate at that position - the camera is
+  // static at the world origin with a zoom of 1 (see `createCamera` above),
+  // so screen coordinates can be converted to world coordinates directly,
+  // once scaled by the camera's pixels-per-unit.
+  renderContext.canvas.addEventListener('mousedown', (event: MouseEvent) => {
+    const canvasBounds = renderContext.canvas.getBoundingClientRect();
+
+    const screenPosition = {
+      x: event.clientX - canvasBounds.left,
+      y: event.clientY - canvasBounds.top,
+    };
+
+    const pixelsPerUnit = calculatePixelsPerUnit(
+      renderContext.height,
+      DEMO_VERTICAL_WORLD_UNITS,
+    );
+
+    const worldPosition = screenToWorldSpace(
+      screenPosition,
+      Vec2.zero,
+      1,
+      renderContext.width,
+      renderContext.height,
+      pixelsPerUnit,
+    );
+
+    spawnCrate(world, crateSprite, worldPosition);
+  });
+
+  return game;
+};

--- a/documentation-site/src/pages/demos/moving-platform/_create-platform.ts
+++ b/documentation-site/src/pages/demos/moving-platform/_create-platform.ts
@@ -1,0 +1,113 @@
+import { EcsWorld } from '@forge-game-engine/forge/ecs';
+import {
+  addPositionComponent,
+  addRotationComponent,
+} from '@forge-game-engine/forge/common';
+import { Vector2 } from '@forge-game-engine/forge/math';
+import {
+  addAabbComponent,
+  addColliderComponent,
+  addRigidBodyComponent,
+  PolygonCollider,
+} from '@forge-game-engine/forge/physics';
+import {
+  addSpriteComponent,
+  createImageSprite,
+  NineSliceOptions,
+  RenderContext,
+} from '@forge-game-engine/forge/rendering';
+import { getAssetUrl } from '@site/src/utils/get-asset-url';
+import { addPlatformMoverComponent } from './_platform-mover.component';
+
+export const platformWidth = 260;
+export const platformHeight = 32;
+export const platformSpeed = 140;
+
+// `block_square.png` is a 64x64 rounded, bolted panel; these insets keep its
+// rounded corners and bolt-head detail at a fixed size while the center
+// stretches to the platform's actual width, instead of smearing them across
+// it (see the same pattern in the prismatic-joint demo).
+const platformSlices: NineSliceOptions = {
+  left: 16,
+  right: 16,
+  top: 16,
+  bottom: 16,
+  nativeWidth: 64,
+  nativeHeight: 64,
+};
+
+function rectangleVertices(width: number, height: number): Vector2[] {
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+
+  return [
+    { x: -halfWidth, y: -halfHeight },
+    { x: halfWidth, y: -halfHeight },
+    { x: halfWidth, y: halfHeight },
+    { x: -halfWidth, y: halfHeight },
+  ];
+}
+
+/**
+ * Creates the demo's kinematic platform: it ping-pongs between `leftX` and
+ * `rightX` at `platformY`, carrying and pushing whatever dynamic crates land
+ * on it, without gravity or collisions ever changing its own velocity (see
+ * `type: 'kinematic'` below, and `_platform-mover.system.ts`, which reverses
+ * its direction at the bounds).
+ * @param world - The ECS world to add the platform entity to.
+ * @param renderContext - The render context used to load the platform sprite.
+ * @param renderLayer - The render layer the platform should be drawn on.
+ * @param leftX - The leftmost X position the platform travels to.
+ * @param rightX - The rightmost X position the platform travels to.
+ * @param platformY - The platform's (constant) Y position.
+ */
+export async function createPlatform(
+  world: EcsWorld,
+  renderContext: RenderContext,
+  renderLayer: number,
+  leftX: number,
+  rightX: number,
+  platformY: number,
+): Promise<void> {
+  const platformImage = await renderContext.imageCache.getOrLoad(
+    getAssetUrl('img/physics/block_square.png'),
+  );
+  const platformSprite = createImageSprite(
+    platformImage,
+    renderContext,
+    renderLayer,
+  );
+
+  const entity = world.createEntity();
+  const startPosition: Vector2 = { x: leftX, y: platformY };
+
+  addPositionComponent(world, entity, {
+    world: { ...startPosition },
+    local: { ...startPosition },
+  });
+  addRotationComponent(world, entity);
+  addSpriteComponent(world, entity, {
+    ...platformSprite,
+    width: platformWidth,
+    height: platformHeight,
+    slices: platformSlices,
+  });
+
+  const collider = new PolygonCollider(
+    rectangleVertices(platformWidth, platformHeight),
+  );
+
+  addColliderComponent(world, entity, { collider, friction: 0.8 });
+  addAabbComponent(world, entity);
+  addRigidBodyComponent(world, entity, {
+    mass: collider.mass,
+    momentOfInertia: collider.momentOfInertia,
+    type: 'kinematic',
+    velocity: { x: platformSpeed, y: 0 },
+  });
+  addPlatformMoverComponent(world, entity, {
+    leftX,
+    rightX,
+    speed: platformSpeed,
+  });
+}

--- a/documentation-site/src/pages/demos/moving-platform/_platform-mover.component.ts
+++ b/documentation-site/src/pages/demos/moving-platform/_platform-mover.component.ts
@@ -1,0 +1,25 @@
+import { createComponentId, EcsWorld } from '@forge-game-engine/forge/ecs';
+
+/**
+ * Drives a kinematic platform back and forth along the X axis between
+ * `leftX` and `rightX`: since a kinematic body's velocity is meant to be
+ * set directly by game code (it's never touched by gravity or impulses),
+ * this is the entity's own "AI" for reversing direction once it reaches
+ * either bound.
+ */
+export interface PlatformMoverEcsComponent {
+  leftX: number;
+  rightX: number;
+  speed: number;
+}
+
+export const platformMoverId =
+  createComponentId<PlatformMoverEcsComponent>('platform-mover');
+
+export function addPlatformMoverComponent(
+  world: EcsWorld,
+  entity: number,
+  options: PlatformMoverEcsComponent,
+): PlatformMoverEcsComponent {
+  return world.addComponent(entity, platformMoverId, options);
+}

--- a/documentation-site/src/pages/demos/moving-platform/_platform-mover.system.ts
+++ b/documentation-site/src/pages/demos/moving-platform/_platform-mover.system.ts
@@ -1,0 +1,40 @@
+import { positionId } from '@forge-game-engine/forge/common';
+import { EcsSystem } from '@forge-game-engine/forge/ecs';
+import { RigidBodyEcsComponent, rigidBodyId } from '@forge-game-engine/forge/physics';
+import {
+  PlatformMoverEcsComponent,
+  platformMoverId,
+} from './_platform-mover.component';
+
+/**
+ * Reverses a `PlatformMoverEcsComponent` entity's kinematic `velocity.x`
+ * once its `PositionEcsComponent.world.x` reaches either `leftX`/`rightX`.
+ * Nothing else drives the platform's motion - `createEulerIntegrationEcsSystem`
+ * moves it every tick from `velocity` alone, exactly like a dynamic body,
+ * the platform just never has gravity/impulses applied to it.
+ */
+export const createPlatformMoverEcsSystem = (): EcsSystem<
+  [PlatformMoverEcsComponent, RigidBodyEcsComponent]
+> => ({
+  query: [platformMoverId, rigidBodyId],
+  update: (world, { entities, components: [movers, rigidBodies] }) => {
+    for (let i = 0; i < entities.length; i++) {
+      const mover = movers[i];
+      const rigidBody = rigidBodies[i];
+      const position = world.getComponent(entities[i], positionId);
+
+      if (position === null) {
+        continue;
+      }
+
+      if (position.world.x <= mover.leftX && rigidBody.velocity.x < 0) {
+        rigidBody.velocity.x = mover.speed;
+      } else if (
+        position.world.x >= mover.rightX &&
+        rigidBody.velocity.x > 0
+      ) {
+        rigidBody.velocity.x = -mover.speed;
+      }
+    }
+  },
+});

--- a/documentation-site/src/pages/demos/moving-platform/_spawn-crates.ts
+++ b/documentation-site/src/pages/demos/moving-platform/_spawn-crates.ts
@@ -1,0 +1,89 @@
+import { EcsWorld } from '@forge-game-engine/forge/ecs';
+import {
+  addPositionComponent,
+  addRotationComponent,
+} from '@forge-game-engine/forge/common';
+import { Vector2 } from '@forge-game-engine/forge/math';
+import {
+  addAabbComponent,
+  addColliderComponent,
+  addGravityComponent,
+  addRigidBodyComponent,
+  PolygonCollider,
+} from '@forge-game-engine/forge/physics';
+import {
+  addSpriteComponent,
+  createImageSprite,
+  RenderContext,
+  SpriteEcsComponent,
+} from '@forge-game-engine/forge/rendering';
+import { getAssetUrl } from '@site/src/utils/get-asset-url';
+
+export const crateSize = 36;
+const gravity = { x: 0, y: -500 };
+
+function rectangleVertices(width: number, height: number): Vector2[] {
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+
+  return [
+    { x: -halfWidth, y: -halfHeight },
+    { x: halfWidth, y: -halfHeight },
+    { x: halfWidth, y: halfHeight },
+    { x: -halfWidth, y: halfHeight },
+  ];
+}
+
+/**
+ * Loads the crate sprite once, up front, so `spawnCrate` (called repeatedly,
+ * including from a click handler) never re-triggers an image load.
+ * @param renderContext - The render context used to load the crate sprite.
+ * @param renderLayer - The render layer crates should be drawn on.
+ * @returns The crate sprite, ready to pass into `spawnCrate`.
+ */
+export async function loadCrateSprite(
+  renderContext: RenderContext,
+  renderLayer: number,
+): Promise<SpriteEcsComponent> {
+  const crateImage = await renderContext.imageCache.getOrLoad(
+    getAssetUrl('img/physics/block_square.png'),
+  );
+
+  return createImageSprite(crateImage, renderContext, renderLayer);
+}
+
+/**
+ * Spawns a single dynamic crate at `position`, which falls under gravity and
+ * lands on (or is pushed by) the kinematic platform.
+ * @param world - The ECS world to add the crate entity to.
+ * @param sprite - The crate sprite, from `loadCrateSprite`.
+ * @param position - The world-space position to spawn the crate at.
+ */
+export function spawnCrate(
+  world: EcsWorld,
+  sprite: SpriteEcsComponent,
+  position: Vector2,
+): void {
+  const entity = world.createEntity();
+
+  addPositionComponent(world, entity, {
+    world: { ...position },
+    local: { ...position },
+  });
+  addRotationComponent(world, entity);
+  addSpriteComponent(world, entity, {
+    ...sprite,
+    width: crateSize,
+    height: crateSize,
+  });
+
+  const collider = new PolygonCollider(rectangleVertices(crateSize, crateSize));
+
+  addColliderComponent(world, entity, { collider, friction: 0.6 });
+  addAabbComponent(world, entity);
+  addRigidBodyComponent(world, entity, {
+    mass: collider.mass,
+    momentOfInertia: collider.momentOfInertia,
+  });
+  addGravityComponent(world, entity, { amount: gravity });
+}

--- a/documentation-site/src/pages/demos/moving-platform/index.tsx
+++ b/documentation-site/src/pages/demos/moving-platform/index.tsx
@@ -1,0 +1,39 @@
+import React, { JSX } from 'react';
+import { createMovingPlatformGame } from './_create-game';
+import gameCode from '!!raw-loader!./_create-game';
+import createBoundariesCode from '!!raw-loader!./_create-boundaries';
+import createPlatformCode from '!!raw-loader!./_create-platform';
+import platformMoverComponentCode from '!!raw-loader!./_platform-mover.component';
+import platformMoverSystemCode from '!!raw-loader!./_platform-mover.system';
+import spawnCratesCode from '!!raw-loader!./_spawn-crates';
+
+import { Demo } from '@site/src/components/Demo';
+
+export default function MovingPlatform(): JSX.Element {
+  return (
+    <Demo
+      metaData={{
+        title: 'Moving Platform Demo',
+        description:
+          "A demo showcasing RigidBodyEcsComponent's kinematic body type: a platform driven directly by game code that carries and pushes dynamic crates without being affected by gravity or collisions itself.",
+      }}
+      header="Moving Platform"
+      blurb="The platform is a kinematic body (type: 'kinematic'): a small demo-only system (see platform-mover.component.ts and platform-mover.system.ts) sets its velocity directly and reverses it at either end, and createEulerIntegrationEcsSystem moves it every tick from that velocity, exactly like a dynamic body. But unlike a dynamic body, gravity and collisions never change the platform's own velocity - only the crates react, getting carried along and pushed as the platform sweeps under them. Click anywhere to drop another crate."
+      createGame={createMovingPlatformGame}
+      codeFiles={[
+        { name: 'game.ts', content: gameCode },
+        { name: 'create-platform.ts', content: createPlatformCode },
+        {
+          name: 'platform-mover.component.ts',
+          content: platformMoverComponentCode,
+        },
+        {
+          name: 'platform-mover.system.ts',
+          content: platformMoverSystemCode,
+        },
+        { name: 'spawn-crates.ts', content: spawnCratesCode },
+        { name: 'create-boundaries.ts', content: createBoundariesCode },
+      ]}
+    />
+  );
+}

--- a/src/physics/apply-explosive-force.ts
+++ b/src/physics/apply-explosive-force.ts
@@ -8,8 +8,9 @@ import { RigidBodyEcsComponent, rigidBodyId } from './components/index.js';
  * Applies a radial impulse to every dynamic body within `radius` of
  * `center`, strongest at `center` and falling off linearly to zero at
  * `radius`. The impulse passes through each body's center of mass, so it
- * never imparts spin. Bodies with no `RigidBodyEcsComponent` (static
- * geometry) and bodies at or beyond `radius` are untouched.
+ * never imparts spin. Bodies with no `RigidBodyEcsComponent`,
+ * `'static'`/`'kinematic'` bodies (see {@link RigidBodyType}; `applyImpulse`
+ * no-ops for them), and bodies at or beyond `radius` are untouched.
  * @param world - The ECS world to search for dynamic bodies in.
  * @param center - The explosion's world-space origin.
  * @param force - The impulse magnitude at `center`.

--- a/src/physics/apply-impluse.test.ts
+++ b/src/physics/apply-impluse.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { applyImpulse } from './apply-impluse.js';
+import { RigidBodyEcsComponent } from './components/index.js';
+import { Vec2 } from '../math/index.js';
+
+describe('applyImpulse', () => {
+  it('changes velocity by impulse * (1 / mass) for a dynamic body', () => {
+    const rigidBody: RigidBodyEcsComponent = {
+      mass: 2,
+      momentOfInertia: 1,
+      velocity: Vec2.zero,
+      angularVelocity: 0,
+      angularDrag: 0,
+      type: 'dynamic',
+    };
+
+    applyImpulse({ x: 10, y: 0 }, { x: 0, y: 0 }, { x: 0, y: 0 }, rigidBody);
+
+    expect(rigidBody.velocity).toEqual({ x: 5, y: 0 });
+  });
+
+  it('imparts spin when the impulse is applied off-center', () => {
+    const rigidBody: RigidBodyEcsComponent = {
+      mass: 1,
+      momentOfInertia: 1,
+      velocity: Vec2.zero,
+      angularVelocity: 0,
+      angularDrag: 0,
+      type: 'dynamic',
+    };
+
+    applyImpulse({ x: 0, y: 1 }, { x: 1, y: 0 }, { x: 0, y: 0 }, rigidBody);
+
+    expect(rigidBody.angularVelocity).not.toBe(0);
+  });
+
+  it.each(['static', 'kinematic'] as const)(
+    'does not change velocity or angularVelocity for a %s body',
+    (type) => {
+      const rigidBody: RigidBodyEcsComponent = {
+        mass: 1,
+        momentOfInertia: 1,
+        velocity: Vec2.zero,
+        angularVelocity: 0,
+        angularDrag: 0,
+        type,
+      };
+
+      applyImpulse({ x: 10, y: 5 }, { x: 1, y: 1 }, { x: 0, y: 0 }, rigidBody);
+
+      expect(rigidBody.velocity).toEqual({ x: 0, y: 0 });
+      expect(rigidBody.angularVelocity).toBe(0);
+    },
+  );
+});

--- a/src/physics/apply-impluse.ts
+++ b/src/physics/apply-impluse.ts
@@ -1,12 +1,27 @@
 import { Vec2, Vector2 } from '../math/index.js';
 import { RigidBodyEcsComponent } from './components/index.js';
 
+/**
+ * Applies `impulse` at `impulseWorldPosition` to `rigidBody`'s velocity and
+ * angular velocity. A no-op if `rigidBody.type` (see
+ * {@link RigidBodyType}) isn't `'dynamic'`, since `'static'`/`'kinematic'`
+ * bodies aren't affected by impulses.
+ * @param impulse - The impulse to apply.
+ * @param impulseWorldPosition - The world-space point `impulse` is applied
+ * at.
+ * @param entityPosition - `rigidBody`'s entity's current world position.
+ * @param rigidBody - The rigid body to apply the impulse to.
+ */
 export function applyImpulse(
   impulse: Vector2,
   impulseWorldPosition: Vector2,
   entityPosition: Vector2,
   rigidBody: RigidBodyEcsComponent,
 ): void {
+  if (rigidBody.type !== 'dynamic') {
+    return;
+  }
+
   // Clone before subtracting/multiplying: callers may pass the same object
   // for `impulseWorldPosition`/`entityPosition` (or a live world position),
   // and may reuse `impulse` afterward, so none of these may be mutated.

--- a/src/physics/apply-torque.test.ts
+++ b/src/physics/apply-torque.test.ts
@@ -11,6 +11,7 @@ describe('applyTorque', () => {
       velocity: Vec2.zero,
       angularVelocity: 0,
       angularDrag: 0,
+      type: 'dynamic',
     };
 
     applyTorque(4, 0.5, rigidBody);
@@ -25,10 +26,29 @@ describe('applyTorque', () => {
       velocity: Vec2.zero,
       angularVelocity: 2,
       angularDrag: 0,
+      type: 'dynamic',
     };
 
     applyTorque(-1, 1, rigidBody);
 
     expect(rigidBody.angularVelocity).toBeCloseTo(1);
   });
+
+  it.each(['static', 'kinematic'] as const)(
+    'should not change angularVelocity for a %s body',
+    (type) => {
+      const rigidBody: RigidBodyEcsComponent = {
+        mass: 1,
+        momentOfInertia: 2,
+        velocity: Vec2.zero,
+        angularVelocity: 0,
+        angularDrag: 0,
+        type,
+      };
+
+      applyTorque(4, 0.5, rigidBody);
+
+      expect(rigidBody.angularVelocity).toBe(0);
+    },
+  );
 });

--- a/src/physics/apply-torque.ts
+++ b/src/physics/apply-torque.ts
@@ -9,6 +9,10 @@ import { RigidBodyEcsComponent } from './components/index.js';
  * thruster held down for a frame); for torque that continuously drives a
  * body toward a target angular velocity, use an
  * `AngularVelocityMotorEcsComponent` instead.
+ *
+ * A no-op if `rigidBody.type` (see {@link RigidBodyType}) isn't
+ * `'dynamic'`, since `'static'`/`'kinematic'` bodies aren't affected by
+ * torque.
  * @param torque - The torque to apply, in newton-meters. Positive spins
  * counter-clockwise, matching `Vector2.cross`'s sign convention.
  * @param deltaTimeInSeconds - This tick's delta time, used to convert
@@ -20,6 +24,10 @@ export function applyTorque(
   deltaTimeInSeconds: number,
   rigidBody: RigidBodyEcsComponent,
 ): void {
+  if (rigidBody.type !== 'dynamic') {
+    return;
+  }
+
   rigidBody.angularVelocity +=
     (torque * deltaTimeInSeconds) / rigidBody.momentOfInertia;
 }

--- a/src/physics/components/rigidbody-component.test.ts
+++ b/src/physics/components/rigidbody-component.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { addRigidBodyComponent, rigidBodyId } from './rigidbody-component.js';
+import { EcsWorld } from '../../ecs/index.js';
+
+describe('addRigidBodyComponent', () => {
+  it('defaults type to dynamic', () => {
+    const world = new EcsWorld();
+    const entity = world.createEntity();
+
+    addRigidBodyComponent(world, entity, { mass: 1, momentOfInertia: 1 });
+
+    const rigidBody = world.getComponent(entity, rigidBodyId)!;
+
+    expect(rigidBody.type).toBe('dynamic');
+  });
+
+  it.each(['static', 'kinematic', 'dynamic'] as const)(
+    'accepts an explicit type of %s',
+    (type) => {
+      const world = new EcsWorld();
+      const entity = world.createEntity();
+
+      addRigidBodyComponent(world, entity, {
+        mass: 1,
+        momentOfInertia: 1,
+        type,
+      });
+
+      const rigidBody = world.getComponent(entity, rigidBodyId)!;
+
+      expect(rigidBody.type).toBe(type);
+    },
+  );
+});

--- a/src/physics/components/rigidbody-component.ts
+++ b/src/physics/components/rigidbody-component.ts
@@ -3,6 +3,26 @@ import { EcsWorld } from '../../ecs/ecs-world.js';
 import { Vec2, Vector2 } from '../../math/index.js';
 
 /**
+ * How a {@link RigidBodyEcsComponent} participates in the simulation:
+ *
+ * - `'dynamic'`: fully simulated. Affected by gravity, forces, and impulses;
+ *   pushed apart by collisions; integrated into position every tick.
+ * - `'kinematic'`: moved directly by game code (by setting `velocity`, or
+ *   position itself). Not affected by gravity, forces, or collision
+ *   impulses, but still integrated into position from `velocity` every tick
+ *   and still pushes dynamic bodies it contacts. Use this for moving
+ *   platforms and other scripted movers that dynamic bodies should react to.
+ * - `'static'`: never moves and is never integrated, with infinite effective
+ *   mass in the solver. Equivalent to an entity with no
+ *   `RigidBodyEcsComponent` at all (the convention every collider-only
+ *   entity, e.g. `TerrainCollider` ground, already follows); attaching a
+ *   `RigidBodyEcsComponent` with this type is only useful when other
+ *   components on the entity (e.g. a motor or joint) require one to be
+ *   present.
+ */
+export type RigidBodyType = 'dynamic' | 'kinematic' | 'static';
+
+/**
  * Fields of {@link RigidBodyEcsComponent} with a sensible default; callers
  * may omit these.
  */
@@ -14,6 +34,12 @@ export interface RigidBodyDefaultedOptions {
    * damping. Applied by {@link createEulerIntegrationEcsSystem}.
    */
   angularDrag: number;
+
+  /**
+   * How this body participates in the simulation. Defaults to `'dynamic'`.
+   * See {@link RigidBodyType}.
+   */
+  type: RigidBodyType;
 }
 
 export interface RigidBodyRequiredOptions {
@@ -46,6 +72,7 @@ export function addRigidBodyComponent(
     velocity: Vec2.zero,
     angularVelocity: 0,
     angularDrag: 0,
+    type: 'dynamic',
   };
 
   const component: RigidBodyEcsComponent = {

--- a/src/physics/index.ts
+++ b/src/physics/index.ts
@@ -6,6 +6,7 @@ export * from './collision/index.js';
 export * from './components/index.js';
 export * from './joints/index.js';
 export * from './raycast/index.js';
+export * from './rigid-body-inverse-mass.js';
 export * from './solve-soft-constraint.js';
 export * from './systems/index.js';
 export * from './types/index.js';

--- a/src/physics/joints/apply-point-impulse.ts
+++ b/src/physics/joints/apply-point-impulse.ts
@@ -4,15 +4,21 @@ import { RigidBodyEcsComponent } from '../components/rigidbody-component.js';
 /**
  * Applies `impulse` at the point `r` (relative to the body's position) to
  * `rigidBody`'s velocity and angular velocity. A `null` `rigidBody` (static
- * geometry) is a no-op, so callers can apply the same impulse to both sides
- * of a constraint without checking whether each side is static themselves.
+ * geometry with no `RigidBodyEcsComponent`) is a no-op, so callers can apply
+ * the same impulse to both sides of a constraint without checking whether
+ * each side is static themselves. Passing `invMass`/`invInertia` of `0` (as
+ * `getRigidBodyInverseMass` returns for a `'static'`/`'kinematic'` body) has
+ * the same zero-effect even when `rigidBody` is non-`null`, which is how a
+ * `'kinematic'` body stays unaffected by contact/joint impulses while still
+ * being read as the "other side" of one.
  * @param rigidBody - The rigid body to apply the impulse to, or `null` for
  * static geometry.
  * @param r - The point to apply `impulse` at, relative to `rigidBody`'s
  * position.
- * @param invMass - `rigidBody`'s precomputed inverse mass (`0` if static).
+ * @param invMass - `rigidBody`'s precomputed inverse mass (`0` if static or
+ * kinematic).
  * @param invInertia - `rigidBody`'s precomputed inverse moment of inertia
- * (`0` if static).
+ * (`0` if static or kinematic).
  * @param impulse - The impulse to apply.
  */
 export function applyPointImpulse(

--- a/src/physics/joints/resolve-joint-body.ts
+++ b/src/physics/joints/resolve-joint-body.ts
@@ -5,12 +5,15 @@ import {
   RigidBodyEcsComponent,
   rigidBodyId,
 } from '../components/rigidbody-component.js';
+import { getRigidBodyInverseMass } from '../rigid-body-inverse-mass.js';
 
 /**
  * A joint constraint's view of one of its two connected entities: its
  * current world position/rotation plus the (inverse) mass/inertia the
- * solver needs. An entity with no `RigidBodyEcsComponent` is treated as
- * static (infinite mass), matching contact resolution's convention.
+ * solver needs. An entity with no `RigidBodyEcsComponent`, or one whose
+ * `RigidBodyEcsComponent.type` is `'static'`/`'kinematic'`, is treated as
+ * having infinite mass, matching contact resolution's convention (see
+ * {@link getRigidBodyInverseMass}).
  */
 export interface JointBody {
   readonly rigidBody: RigidBodyEcsComponent | null;
@@ -42,11 +45,12 @@ export function resolveJointBody(
   }
 
   const rigidBody = world.getComponent(entity, rigidBodyId);
+  const { invMass, invInertia } = getRigidBodyInverseMass(rigidBody);
 
   return {
     rigidBody,
-    invMass: rigidBody ? 1 / rigidBody.mass : 0,
-    invInertia: rigidBody ? 1 / rigidBody.momentOfInertia : 0,
+    invMass,
+    invInertia,
     position: position.world,
     rotation: rotation.world,
   };

--- a/src/physics/joints/velocity-at-point.ts
+++ b/src/physics/joints/velocity-at-point.ts
@@ -4,7 +4,11 @@ import { RigidBodyEcsComponent } from '../components/rigidbody-component.js';
 /**
  * The velocity of the point `r` (relative to `rigidBody`'s position) on a
  * rotating, translating body: `velocity + angularVelocity × r`. Bodies with
- * no rigid body (static geometry) have no velocity anywhere.
+ * no rigid body (static geometry) have no velocity anywhere. A
+ * `'kinematic'` body's `velocity`/`angularVelocity` (set directly by game
+ * code) is read normally here even though it has `0` inverse mass/inertia
+ * in the solver - this is what lets a kinematic body still push a dynamic
+ * body it contacts.
  * @param rigidBody - The rigid body, or `null` for static geometry.
  * @param r - The point to sample velocity at, relative to `rigidBody`'s
  * position.

--- a/src/physics/rigid-body-inverse-mass.test.ts
+++ b/src/physics/rigid-body-inverse-mass.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { RigidBodyEcsComponent } from './components/index.js';
+import { getRigidBodyInverseMass } from './rigid-body-inverse-mass.js';
+import { Vec2 } from '../math/index.js';
+
+function createRigidBody(
+  type: RigidBodyEcsComponent['type'],
+): RigidBodyEcsComponent {
+  return {
+    mass: 2,
+    momentOfInertia: 4,
+    velocity: Vec2.zero,
+    angularVelocity: 0,
+    angularDrag: 0,
+    type,
+  };
+}
+
+describe('getRigidBodyInverseMass', () => {
+  it('returns 0/0 for a null rigid body', () => {
+    expect(getRigidBodyInverseMass(null)).toEqual({
+      invMass: 0,
+      invInertia: 0,
+    });
+  });
+
+  it('returns 1/mass and 1/momentOfInertia for a dynamic body', () => {
+    expect(getRigidBodyInverseMass(createRigidBody('dynamic'))).toEqual({
+      invMass: 0.5,
+      invInertia: 0.25,
+    });
+  });
+
+  it.each(['static', 'kinematic'] as const)(
+    'returns 0/0 for a %s body',
+    (type) => {
+      expect(getRigidBodyInverseMass(createRigidBody(type))).toEqual({
+        invMass: 0,
+        invInertia: 0,
+      });
+    },
+  );
+});

--- a/src/physics/rigid-body-inverse-mass.ts
+++ b/src/physics/rigid-body-inverse-mass.ts
@@ -1,0 +1,37 @@
+import { RigidBodyEcsComponent } from './components/rigidbody-component.js';
+
+/**
+ * A rigid body's inverse mass/inertia, as the contact and joint solvers use
+ * them.
+ */
+export interface RigidBodyInverseMass {
+  invMass: number;
+  invInertia: number;
+}
+
+/**
+ * Resolves the inverse mass/inertia the solver should use for `rigidBody`:
+ * `1 / mass` and `1 / momentOfInertia` for a `'dynamic'` body, or `0`/`0`
+ * (infinite effective mass) for a `'static'`/`'kinematic'` body or a `null`
+ * `rigidBody` (an entity with no `RigidBodyEcsComponent`, the static
+ * convention every collider-only entity follows). `0` inverse mass/inertia
+ * is what makes `applyPointImpulse` a no-op for these bodies, so they're
+ * never moved by a collision or joint impulse - but their (possibly
+ * user-set) `velocity` is still read by `velocityAtPoint`, which is what
+ * lets a kinematic body still push a dynamic body it contacts.
+ * @param rigidBody - The rigid body to resolve, or `null` for static
+ * geometry with no `RigidBodyEcsComponent`.
+ * @returns The resolved `invMass`/`invInertia`.
+ */
+export function getRigidBodyInverseMass(
+  rigidBody: RigidBodyEcsComponent | null,
+): RigidBodyInverseMass {
+  if (rigidBody === null || rigidBody.type !== 'dynamic') {
+    return { invMass: 0, invInertia: 0 };
+  }
+
+  return {
+    invMass: 1 / rigidBody.mass,
+    invInertia: 1 / rigidBody.momentOfInertia,
+  };
+}

--- a/src/physics/systems/angular-velocity-motor-system.ts
+++ b/src/physics/systems/angular-velocity-motor-system.ts
@@ -17,7 +17,9 @@ import {
  * external disturbance (a collision, a scripted torque). Order relative to
  * other physics systems doesn't matter beyond running before whatever
  * system integrates velocity into position
- * (`createEulerIntegrationEcsSystem`).
+ * (`createEulerIntegrationEcsSystem`). Entities whose `RigidBodyEcsComponent.type`
+ * (see {@link RigidBodyType}) isn't `'dynamic'` are skipped, since
+ * `'static'`/`'kinematic'` bodies aren't affected by torque.
  * @param time - Used to read the tick's delta time.
  * @returns An ECS system that drives every motor-equipped entity's angular
  * velocity every tick.
@@ -34,8 +36,13 @@ export const createAngularVelocityMotorEcsSystem = (
     }
 
     for (let i = 0; i < motors.length; i++) {
-      const motor = motors[i];
       const rigidBody = rigidBodies[i];
+
+      if (rigidBody.type !== 'dynamic') {
+        continue;
+      }
+
+      const motor = motors[i];
 
       const velocityError = motor.targetVelocity - rigidBody.angularVelocity;
       const impulse = rigidBody.momentOfInertia * velocityError;

--- a/src/physics/systems/collision-resolution-system.test.ts
+++ b/src/physics/systems/collision-resolution-system.test.ts
@@ -122,6 +122,34 @@ describe('createCollisionResolutionEcsSystem', () => {
     expect(relativeNormalVelocity).toBeGreaterThan(-1e-3);
   });
 
+  it('should let a kinematic body push a dynamic body without being affected itself', () => {
+    addSystem({ restitutionThreshold: 100 });
+
+    const { entity: platform, rigidBody: platformBody } = addCircleEntity(
+      { x: 0, y: 0 },
+      1,
+      true,
+      { restitution: 0 },
+      { type: 'kinematic' },
+    );
+    const { entity: box, rigidBody: boxBody } = addCircleEntity(
+      { x: 1.5, y: 0 },
+      1,
+      true,
+      { restitution: 0 },
+    );
+
+    platformBody!.velocity = { x: 1, y: 0 };
+    boxBody!.velocity = { x: 0, y: 0 };
+
+    pushManifold(platform, box, { x: 1, y: 0 }, 0.5, { x: 0.75, y: 0 });
+
+    world.update();
+
+    expect(platformBody!.velocity).toEqual({ x: 1, y: 0 });
+    expect(boxBody!.velocity.x).toBeGreaterThan(0);
+  });
+
   it('should apply restitution to a fast, newly-appearing impact', () => {
     addSystem();
 

--- a/src/physics/systems/collision-resolution-system.ts
+++ b/src/physics/systems/collision-resolution-system.ts
@@ -12,6 +12,7 @@ import {
 } from '../components/rigidbody-component.js';
 import { applyPointImpulse } from '../joints/apply-point-impulse.js';
 import { velocityAtPoint } from '../joints/velocity-at-point.js';
+import { getRigidBodyInverseMass } from '../rigid-body-inverse-mass.js';
 import { getSoftConstraintParams } from '../solve-soft-constraint.js';
 import { CollisionManifold } from '../types/collision-manifold.js';
 import { ContactConstraint } from '../types/contact-constraint.js';
@@ -243,8 +244,9 @@ function buildContactConstraints(
 /**
  * Looks up the current tick's bodies for a contact constraint, computing
  * the (inverse) mass/inertia and contact-point offsets the solver needs. An
- * entity with no `RigidBodyEcsComponent` is treated as having infinite mass
- * (static geometry).
+ * entity with no `RigidBodyEcsComponent`, or one whose
+ * `RigidBodyEcsComponent.type` is `'static'`/`'kinematic'`, is treated as
+ * having infinite mass (see {@link getRigidBodyInverseMass}).
  */
 function prepareContact(
   world: EcsWorld,
@@ -260,10 +262,10 @@ function prepareContact(
   const rigidBodyA = world.getComponent(constraint.entityA, rigidBodyId);
   const rigidBodyB = world.getComponent(constraint.entityB, rigidBodyId);
 
-  const invMassA = rigidBodyA ? 1 / rigidBodyA.mass : 0;
-  const invMassB = rigidBodyB ? 1 / rigidBodyB.mass : 0;
-  const invInertiaA = rigidBodyA ? 1 / rigidBodyA.momentOfInertia : 0;
-  const invInertiaB = rigidBodyB ? 1 / rigidBodyB.momentOfInertia : 0;
+  const { invMass: invMassA, invInertia: invInertiaA } =
+    getRigidBodyInverseMass(rigidBodyA);
+  const { invMass: invMassB, invInertia: invInertiaB } =
+    getRigidBodyInverseMass(rigidBodyB);
 
   // Clone before subtracting: `constraint.point` is used for both `rA` and
   // `rB` here, and `positionA.world`/`positionB.world` are the entities'

--- a/src/physics/systems/euler-integration-system.test.ts
+++ b/src/physics/systems/euler-integration-system.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createEulerIntegrationEcsSystem } from './euler-integration-system.js';
+import {
+  addPositionComponent,
+  addRotationComponent,
+  positionId,
+  rotationId,
+  Time,
+} from '../../common/index.js';
+import { EcsWorld } from '../../ecs/index.js';
+import {
+  addRigidBodyComponent,
+  RigidBodyType,
+} from '../components/rigidbody-component.js';
+
+describe('createEulerIntegrationEcsSystem', () => {
+  let world: EcsWorld;
+  let time: Time;
+
+  beforeEach(() => {
+    world = new EcsWorld();
+    time = new Time();
+    time.update(0);
+    time.update(1000 / 60);
+
+    world.addSystem(createEulerIntegrationEcsSystem(time));
+  });
+
+  function createBody(type: RigidBodyType): number {
+    const entity = world.createEntity();
+
+    addPositionComponent(world, entity, {
+      world: { x: 0, y: 0 },
+      local: { x: 0, y: 0 },
+    });
+    addRotationComponent(world, entity);
+
+    addRigidBodyComponent(world, entity, {
+      mass: 1,
+      momentOfInertia: 1,
+      velocity: { x: 1, y: 0 },
+      angularVelocity: 1,
+      type,
+    });
+
+    return entity;
+  }
+
+  it('integrates a dynamic body position/rotation from velocity/angularVelocity', () => {
+    const entity = createBody('dynamic');
+
+    world.update();
+
+    const position = world.getComponent(entity, positionId)!;
+    const rotation = world.getComponent(entity, rotationId)!;
+
+    expect(position.world.x).toBeGreaterThan(0);
+    expect(rotation.world).toBeGreaterThan(0);
+  });
+
+  it('integrates a kinematic body the same as a dynamic one', () => {
+    const entity = createBody('kinematic');
+
+    world.update();
+
+    const position = world.getComponent(entity, positionId)!;
+    const rotation = world.getComponent(entity, rotationId)!;
+
+    expect(position.world.x).toBeGreaterThan(0);
+    expect(rotation.world).toBeGreaterThan(0);
+  });
+
+  it('never moves a static body, even with a nonzero velocity', () => {
+    const entity = createBody('static');
+
+    world.update();
+
+    const position = world.getComponent(entity, positionId)!;
+    const rotation = world.getComponent(entity, rotationId)!;
+
+    expect(position.world).toEqual({ x: 0, y: 0 });
+    expect(rotation.world).toBe(0);
+  });
+});

--- a/src/physics/systems/euler-integration-system.ts
+++ b/src/physics/systems/euler-integration-system.ts
@@ -15,7 +15,11 @@ import {
 /**
  * Creates an ECS system to Euler integration of rigid body entities.
  * @returns An ECS system that updates position and rotation of a rigid body
- * based their respective velocity and angular velocity.
+ * based their respective velocity and angular velocity. `'static'` bodies
+ * (see {@link RigidBodyType}) are skipped entirely - they never move and
+ * are never integrated - while `'kinematic'` bodies are integrated the same
+ * as `'dynamic'` ones, since a kinematic body's `velocity` is expected to be
+ * driven directly by game code.
  */
 export const createEulerIntegrationEcsSystem = (
   time: Time,
@@ -25,9 +29,14 @@ export const createEulerIntegrationEcsSystem = (
   query: [positionId, rotationId, rigidBodyId],
   update: (_world, { components: [positions, rotations, rigidBodies] }) => {
     for (let i = 0; i < positions.length; i++) {
+      const rigidBodyComponent = rigidBodies[i];
+
+      if (rigidBodyComponent.type === 'static') {
+        continue;
+      }
+
       const positionComponent = positions[i];
       const rotationComponent = rotations[i];
-      const rigidBodyComponent = rigidBodies[i];
 
       rotationComponent.world +=
         rigidBodyComponent.angularVelocity * time.deltaTimeInSeconds;

--- a/src/physics/systems/gravity-system.test.ts
+++ b/src/physics/systems/gravity-system.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createGravityEcsSystem } from './gravity-system.js';
+import { Time } from '../../common/index.js';
+import { EcsWorld } from '../../ecs/index.js';
+import { addGravityComponent } from '../components/gravity-component.js';
+import {
+  addRigidBodyComponent,
+  RigidBodyType,
+} from '../components/rigidbody-component.js';
+
+describe('createGravityEcsSystem', () => {
+  let world: EcsWorld;
+  let time: Time;
+
+  beforeEach(() => {
+    world = new EcsWorld();
+    time = new Time();
+    time.update(0);
+    time.update(1000 / 60);
+
+    world.addSystem(createGravityEcsSystem(time));
+  });
+
+  function createBody(type: RigidBodyType) {
+    const entity = world.createEntity();
+
+    const rigidBody = addRigidBodyComponent(world, entity, {
+      mass: 1,
+      momentOfInertia: 1,
+      type,
+    });
+    addGravityComponent(world, entity, { amount: { x: 0, y: -10 } });
+
+    return rigidBody;
+  }
+
+  it('accelerates a dynamic body downward', () => {
+    const rigidBody = createBody('dynamic');
+
+    world.update();
+
+    expect(rigidBody.velocity.y).toBeLessThan(0);
+  });
+
+  it.each(['static', 'kinematic'] as const)(
+    'does not accelerate a %s body',
+    (type) => {
+      const rigidBody = createBody(type);
+
+      world.update();
+
+      expect(rigidBody.velocity).toEqual({ x: 0, y: 0 });
+    },
+  );
+});

--- a/src/physics/systems/gravity-system.ts
+++ b/src/physics/systems/gravity-system.ts
@@ -12,7 +12,9 @@ import {
 
 /**
  * Creates an ECS system to handle gravity of rigid body entities.
- * @returns An ECS system that updates velocity of a rigid body based on gravity.
+ * @returns An ECS system that updates velocity of a rigid body based on
+ * gravity. `'static'` and `'kinematic'` bodies (see {@link RigidBodyType})
+ * are skipped - neither is affected by forces.
  */
 export const createGravityEcsSystem = (
   time: Time,
@@ -21,6 +23,11 @@ export const createGravityEcsSystem = (
   update: (_world, { components: [rigidBodies, gravities] }) => {
     for (let i = 0; i < rigidBodies.length; i++) {
       const rigidBodyComponent = rigidBodies[i];
+
+      if (rigidBodyComponent.type !== 'dynamic') {
+        continue;
+      }
+
       const gravityComponent = gravities[i];
 
       // Clone before scaling: `gravityComponent.amount` is a persistent


### PR DESCRIPTION
## Summary

Adds an explicit `RigidBodyEcsComponent.type` field (`'dynamic'` | `'kinematic'` | `'static'`, defaulting to `'dynamic'`) so bodies moved directly by game code (e.g. a moving platform) can push dynamic bodies around without being affected by forces/impulses themselves, per #561.

- `'dynamic'` (default): current fully-simulated behavior, unchanged.
- `'kinematic'`: integrated into position from `velocity` every tick (so it can be driven by setting `velocity` once), but skipped by gravity/`applyImpulse`/`applyTorque`/the angular-velocity motor, and treated as infinite mass by the contact/joint solvers — yet its (user-set) velocity is still read when resolving contacts, so it still pushes dynamic bodies it touches.
- `'static'`: skipped by `createEulerIntegrationEcsSystem` (never moves, never integrated) and treated as infinite mass, matching the existing "no `RigidBodyEcsComponent`" convention exactly — that convention is untouched and still works.

The (inverse) mass/inertia lookup that both the contact solver (`collision-resolution-system.ts`) and the joint solver (`resolve-joint-body.ts`) duplicated is now centralized in a new `getRigidBodyInverseMass` helper, so `'static'`/`'kinematic'` bodies get `0` inverse mass/inertia (infinite effective mass) consistently everywhere.

## Related issue(s)

Closes #561

## Verification checklist

- [x] `npm run check-types` passes with 0 errors
- [x] `npm test` passes (985 tests, including new coverage for the type field across `rigidbody-component`, `euler-integration-system`, `gravity-system`, `collision-resolution-system`, `apply-impluse`, `apply-torque`, and the new `rigid-body-inverse-mass` helper)
- [x] `npm run lint` passes with 0 errors
- [x] `npm run cspell` passes with 0 errors
- [x] `npm run check-exports` passes
- [x] Any new/changed public API is exported from the module's `index.ts` (`RigidBodyType`/`getRigidBodyInverseMass` are exported from `src/physics/index.ts`)
- [x] Documentation under `/documentation-site/docs/docs` is updated (`physics/rigid-bodies.md` and `physics/index.md` were rewritten to describe the current ECS-native physics API — they had drifted to describe an older, no-longer-existing `PhysicsWorld`/`RigidBody` class API — and now document `type`; `physics/terrain.md` got a one-line update)
- [x] This change touches `/physics`, which has demos under `/documentation-site/src/pages/demos` (`physics`, `rolling-ball`, etc.) — no demo code needed updating since `type` defaults to `'dynamic'` (unchanged behavior), but I ran `npm run build`, `documentation-site`'s `npm run typecheck`/`npm run build`, and loaded the Physics and Rolling Ball demo pages plus the rewritten docs page in a browser to confirm they render correctly

## Changelog

- [x] Added a bullet under `## [Unreleased]` → `#### Added` in `CHANGELOG.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01J8n9j1k1aUdLwynFznXur3)_