### PR TITLE
test(input): improve unit test coverage across the input module

### DIFF
--- a/src/input/actions/axis-1d-action.test.ts
+++ b/src/input/actions/axis-1d-action.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Axis1dAction } from './axis-1d-action';
+import { actionResetTypes } from '../constants';
 
 describe('InputAxis1d', () => {
   let action: Axis1dAction;
@@ -34,5 +35,43 @@ describe('InputAxis1d', () => {
 
     action.reset();
     expect(action.value).toBe(0);
+  });
+
+  it('should default the input group to "game" when not provided', () => {
+    const defaultGroupAction = new Axis1dAction('zoom');
+    expect(defaultGroupAction.inputGroup).toBe('game');
+  });
+
+  it('should not reset the value when the reset type is noReset', () => {
+    const noResetAction = new Axis1dAction(
+      'zoom',
+      'default',
+      actionResetTypes.noReset,
+    );
+
+    noResetAction.set(1);
+    noResetAction.reset();
+
+    expect(noResetAction.value).toBe(1);
+  });
+
+  it('should raise valueChangeEvent when the value changes', () => {
+    const listener = vi.fn();
+
+    action.valueChangeEvent.registerListener(listener);
+    action.set(1);
+
+    expect(listener).toHaveBeenCalledWith(1);
+  });
+
+  it('should not raise valueChangeEvent when set to the same value', () => {
+    action.set(1);
+
+    const listener = vi.fn();
+
+    action.valueChangeEvent.registerListener(listener);
+    action.set(1);
+
+    expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/src/input/actions/axis-2d-action.test.ts
+++ b/src/input/actions/axis-2d-action.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Axis2dAction } from './axis-2d-action';
+import { actionResetTypes } from '../constants';
 
 describe('InputAxis2d', () => {
   let action: Axis2dAction;
@@ -39,5 +40,46 @@ describe('InputAxis2d', () => {
     action.reset();
     expect(action.value.x).toBe(0);
     expect(action.value.y).toBe(0);
+  });
+
+  it('should default the input group to "game" when not provided', () => {
+    const defaultGroupAction = new Axis2dAction('pan');
+    expect(defaultGroupAction.inputGroup).toBe('game');
+  });
+
+  it('should not reset the value when the reset type is noReset', () => {
+    const noResetAction = new Axis2dAction(
+      'pan',
+      'default',
+      actionResetTypes.noReset,
+    );
+
+    noResetAction.set(1, 1);
+    noResetAction.reset();
+
+    expect(noResetAction.value.x).toBe(1);
+    expect(noResetAction.value.y).toBe(1);
+  });
+
+  it('should raise valueChangeEvent when the value changes', () => {
+    const listener = vi.fn();
+
+    action.valueChangeEvent.registerListener(listener);
+    action.set(1, 2);
+
+    expect(listener).toHaveBeenCalledWith(action.value);
+    expect(action.value.x).toBe(1);
+    expect(action.value.y).toBe(2);
+  });
+
+  it('should not raise valueChangeEvent when set to the same value', () => {
+    action.set(1, 2);
+
+    const listener = vi.fn();
+
+    action.valueChangeEvent.registerListener(listener);
+    action.set(1, 2);
+
+    expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/src/input/actions/hold-action.test.ts
+++ b/src/input/actions/hold-action.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HoldAction } from './hold-action';
 
 describe('HoldAction', () => {
@@ -43,5 +43,25 @@ describe('HoldAction', () => {
     expect(action.isHeld).toBe(false);
     action.startHold();
     expect(action.isHeld).toBe(true);
+  });
+
+  it('should default the input group to "game" when not provided', () => {
+    const defaultGroupAction = new HoldAction('accelerate');
+    expect(defaultGroupAction.inputGroup).toBe('game');
+  });
+
+  it('should raise holdStartEvent when started and holdEndEvent when ended', () => {
+    const startListener = vi.fn();
+    const endListener = vi.fn();
+
+    action.holdStartEvent.registerListener(startListener);
+    action.holdEndEvent.registerListener(endListener);
+
+    action.startHold();
+    expect(startListener).toHaveBeenCalledTimes(1);
+    expect(endListener).not.toHaveBeenCalled();
+
+    action.endHold();
+    expect(endListener).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/input/actions/trigger-action.test.ts
+++ b/src/input/actions/trigger-action.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TriggerAction } from './trigger-action';
 
 describe('InputAction', () => {
@@ -43,5 +43,19 @@ describe('InputAction', () => {
     expect(action.isTriggered).toBe(false);
     action.trigger();
     expect(action.isTriggered).toBe(true);
+  });
+
+  it('should default the input group to "game" when not provided', () => {
+    const defaultGroupAction = new TriggerAction('jump');
+    expect(defaultGroupAction.inputGroup).toBe('game');
+  });
+
+  it('should raise triggerEvent when triggered', () => {
+    const listener = vi.fn();
+
+    action.triggerEvent.registerListener(listener);
+    action.trigger();
+
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/input/gamepad/input-sources/gamepad-input-source.test.ts
+++ b/src/input/gamepad/input-sources/gamepad-input-source.test.ts
@@ -251,6 +251,194 @@ describe('GamepadInputSource', () => {
     expect(moveAction.value).toBeCloseTo(0.8);
   });
 
+  it('reads a negative digital button on its own into the bound action', () => {
+    const buttonValues: number[] = [];
+
+    buttonValues[gamepadButtons.dpadRight] = 0;
+    buttonValues[gamepadButtons.dpadLeft] = 1;
+
+    source = createSource([createGamepad([], buttonValues)]);
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        positiveButtonIndex: gamepadButtons.dpadRight,
+        negativeButtonIndex: gamepadButtons.dpadLeft,
+      }),
+    );
+
+    source.update();
+
+    expect(moveAction.value).toBe(-1);
+  });
+
+  it('stops dispatching once the gamepad disconnects mid-session', () => {
+    source = createSource([createGamepad([0.8, 0, 0, 0], [])]);
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        axisIndex: gamepadAxes.leftStickX,
+      }),
+    );
+
+    source.update();
+    expect(moveAction.value).toBeCloseTo(0.8);
+
+    // The gamepad reported by navigator.getGamepads() no longer includes
+    // this gamepad's index (e.g. it was unplugged).
+    getGamepadsSpy.mockReturnValue([]);
+    moveAction.set(0.3);
+
+    source.update();
+
+    expect(moveAction.value).toBeCloseTo(0.3);
+  });
+
+  it('ignores a gamepadconnected event once a gamepad is already tracked', () => {
+    const firstGamepad = createGamepad([0.8, 0, 0, 0], []);
+
+    source = createSource([firstGamepad]);
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        axisIndex: gamepadAxes.leftStickX,
+      }),
+    );
+
+    const secondGamepad = createGamepad([0.2, 0, 0, 0], [], 1);
+
+    getGamepadsSpy.mockReturnValue([firstGamepad, secondGamepad]);
+    window.dispatchEvent(
+      Object.assign(new Event('gamepadconnected'), { gamepad: secondGamepad }),
+    );
+
+    source.update();
+
+    // Still reading from the first gamepad, since it was already tracked.
+    expect(moveAction.value).toBeCloseTo(0.8);
+  });
+
+  it('ignores a gamepadconnected event for a different index than requested', () => {
+    source = createSource();
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        axisIndex: gamepadAxes.leftStickX,
+      }),
+    );
+
+    const otherGamepad = createGamepad([0.8, 0, 0, 0], [], 1);
+
+    getGamepadsSpy.mockReturnValue([undefined, otherGamepad]);
+    window.dispatchEvent(
+      Object.assign(new Event('gamepadconnected'), { gamepad: otherGamepad }),
+    );
+
+    source.update();
+
+    expect(moveAction.value).toBe(0);
+  });
+
+  it('tracks whichever gamepad connects when constructed with index -1', () => {
+    source = new GamepadInputSource(inputManager, -1);
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        axisIndex: gamepadAxes.leftStickX,
+      }),
+    );
+
+    const gamepad = createGamepad([0.8, 0, 0, 0], []);
+
+    getGamepadsSpy.mockReturnValue([gamepad]);
+    window.dispatchEvent(
+      Object.assign(new Event('gamepadconnected'), { gamepad }),
+    );
+
+    source.update();
+
+    expect(moveAction.value).toBeCloseTo(0.8);
+  });
+
+  it('skips disconnected slots while searching backwards for the last-connected gamepad', () => {
+    const gamepads: Gamepad[] = [];
+
+    gamepads[0] = createGamepad([0.6, 0, 0, 0], [], 0);
+    gamepads.length = 2; // gamepads[1] is a hole, simulating a disconnected slot.
+
+    getGamepadsSpy.mockReturnValue(gamepads);
+
+    source = new GamepadInputSource(inputManager, -1);
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        axisIndex: gamepadAxes.leftStickX,
+      }),
+    );
+
+    source.update();
+
+    expect(moveAction.value).toBeCloseTo(0.6);
+  });
+
+  it('treats a missing axis value as 0', () => {
+    // An empty axes array simulates a gamepad that doesn't report an axis
+    // at the requested index.
+    source = createSource([createGamepad([], [])]);
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        axisIndex: gamepadAxes.leftStickX,
+      }),
+    );
+
+    expect(() => source.update()).not.toThrow();
+    expect(moveAction.value).toBe(0);
+  });
+
+  it('treats missing digital button values as 0', () => {
+    // An empty buttons array simulates a gamepad that doesn't report
+    // buttons at the requested indices.
+    source = createSource([createGamepad([], [])]);
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        positiveButtonIndex: gamepadButtons.dpadRight,
+        negativeButtonIndex: gamepadButtons.dpadLeft,
+      }),
+    );
+
+    expect(() => source.update()).not.toThrow();
+    expect(moveAction.value).toBe(0);
+  });
+
+  it('resolves the last-connected gamepad when constructed with index -1', () => {
+    const gamepads: Gamepad[] = [];
+
+    gamepads[2] = createGamepad([0.6, 0, 0, 0], [], 2);
+
+    getGamepadsSpy.mockReturnValue(gamepads);
+
+    source = new GamepadInputSource(inputManager, -1);
+
+    source.axis1dBindings.add(
+      new GamepadAxis1dBinding(moveAction, {
+        axisIndex: gamepadAxes.leftStickX,
+      }),
+    );
+
+    source.update();
+
+    expect(moveAction.value).toBeCloseTo(0.6);
+  });
+
+  it('resolves no gamepad when constructed with index -1 and none are connected', () => {
+    getGamepadsSpy.mockReturnValue([]);
+
+    source = new GamepadInputSource(inputManager, -1);
+
+    expect(() => source.update()).not.toThrow();
+  });
+
   it('stops dispatching once stopped', () => {
     source = createSource();
 

--- a/src/input/input-manager.test.ts
+++ b/src/input/input-manager.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { InputManager } from './input-manager';
-import { Axis1dAction, Axis2dAction, TriggerAction } from './actions';
+import {
+  Axis1dAction,
+  Axis2dAction,
+  HoldAction,
+  TriggerAction,
+} from './actions';
 import { actionResetTypes } from './constants';
 
 describe('InputManager', () => {
@@ -90,6 +95,131 @@ describe('InputManager', () => {
     manager.dispatchAxis2dAction(binding, 1, 5);
     expect(action.value.x).toBe(0);
     expect(action.value.y).toBe(0);
+  });
+
+  it('should dispatch hold start action only for active group', () => {
+    const action = new HoldAction('test-hold-action', group1);
+    const binding = {
+      action,
+      displayText: 'test binding',
+    };
+
+    manager.setActiveGroup(group2);
+    manager.dispatchHoldStartAction(binding);
+    expect(action.isHeld).toBe(false);
+
+    manager.setActiveGroup(group1);
+    manager.dispatchHoldStartAction(binding);
+    expect(action.isHeld).toBe(true);
+  });
+
+  it('should dispatch hold end action regardless of active group', () => {
+    const action = new HoldAction('test-hold-action', group1);
+    const binding = {
+      action,
+      displayText: 'test binding',
+    };
+
+    manager.setActiveGroup(group1);
+    manager.dispatchHoldStartAction(binding);
+    expect(action.isHeld).toBe(true);
+
+    manager.setActiveGroup(group2);
+    manager.dispatchHoldEndAction(binding);
+    expect(action.isHeld).toBe(false);
+  });
+
+  it('should add trigger, axis1d, axis2d, and hold actions and mark them resettable', () => {
+    const triggerAction = new TriggerAction('trigger', group1);
+    const axis1dAction = new Axis1dAction('axis1d', group1);
+    const axis2dAction = new Axis2dAction('axis2d', group1);
+    const holdAction = new HoldAction('hold', group1);
+
+    manager.addTriggerActions(triggerAction);
+    manager.addAxis1dActions(axis1dAction);
+    manager.addAxis2dActions(axis2dAction);
+    manager.addHoldActions(holdAction);
+
+    expect(manager.getTriggerAction('trigger')).toBe(triggerAction);
+    expect(manager.getAxis1dAction('axis1d')).toBe(axis1dAction);
+    expect(manager.getAxis2dAction('axis2d')).toBe(axis2dAction);
+    expect(manager.getHoldAction('hold')).toBe(holdAction);
+
+    triggerAction.trigger();
+    axis1dAction.set(1);
+    axis2dAction.set(1, 1);
+
+    manager.reset();
+
+    expect(triggerAction.isTriggered).toBe(false);
+    expect(axis1dAction.value).toBe(0);
+    expect(axis2dAction.value.x).toBe(0);
+    expect(axis2dAction.value.y).toBe(0);
+  });
+
+  it('should remove trigger, axis1d, axis2d, and hold actions', () => {
+    const triggerAction = new TriggerAction('trigger', group1);
+    const axis1dAction = new Axis1dAction('axis1d', group1);
+    const axis2dAction = new Axis2dAction('axis2d', group1);
+    const holdAction = new HoldAction('hold', group1);
+
+    manager.addTriggerActions(triggerAction);
+    manager.addAxis1dActions(axis1dAction);
+    manager.addAxis2dActions(axis2dAction);
+    manager.addHoldActions(holdAction);
+
+    manager.removeTriggerAction(triggerAction);
+    manager.removeAxis1dAction(axis1dAction);
+    manager.removeAxis2dAction(axis2dAction);
+    manager.removeHoldAction(holdAction);
+
+    expect(() => manager.getTriggerAction('trigger')).toThrow(
+      'No TriggerAction found with name: trigger',
+    );
+    expect(() => manager.getAxis1dAction('axis1d')).toThrow(
+      'No Axis1dAction found with name: axis1d',
+    );
+    expect(() => manager.getAxis2dAction('axis2d')).toThrow(
+      'No Axis2dAction found with name: axis2d',
+    );
+    expect(() => manager.getHoldAction('hold')).toThrow(
+      'No HoldAction found with name: hold',
+    );
+  });
+
+  it('should throw when getting an action that was never added', () => {
+    expect(() => manager.getTriggerAction('missing')).toThrow(
+      'No TriggerAction found with name: missing',
+    );
+    expect(() => manager.getAxis1dAction('missing')).toThrow(
+      'No Axis1dAction found with name: missing',
+    );
+    expect(() => manager.getAxis2dAction('missing')).toThrow(
+      'No Axis2dAction found with name: missing',
+    );
+    expect(() => manager.getHoldAction('missing')).toThrow(
+      'No HoldAction found with name: missing',
+    );
+  });
+
+  it('should throw when getting an action that does not match any other registered action', () => {
+    manager.addTriggerActions(new TriggerAction('trigger', group1));
+    manager.addAxis1dActions(new Axis1dAction('axis1d', group1));
+    manager.addAxis2dActions(new Axis2dAction('axis2d', group1));
+    manager.addHoldActions(new HoldAction('hold', group1));
+
+    expect(() => manager.getTriggerAction('missing')).toThrow(
+      'No TriggerAction found with name: missing',
+    );
+    expect(() => manager.getAxis1dAction('missing')).toThrow(
+      'No Axis1dAction found with name: missing',
+    );
+    expect(() => manager.getAxis2dAction('missing')).toThrow(
+      'No Axis2dAction found with name: missing',
+    );
+    expect(() => manager.getHoldAction('missing')).toThrow(
+      'No HoldAction found with name: missing',
+    );
   });
 
   it('should add and remove updatables', () => {

--- a/src/input/keyboard/bindings/keyboard-axis1d-binding.test.ts
+++ b/src/input/keyboard/bindings/keyboard-axis1d-binding.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { KeyboardAxis1dBinding } from './keyboard-axis1d-binding';
+import { Axis1dAction } from '../../actions';
+import { keyCodes } from '../../constants';
+
+describe('KeyboardAxis1dBinding', () => {
+  const mockAction: Axis1dAction = new Axis1dAction(
+    'testAxis1dAction',
+    'default',
+  );
+
+  it('should create an instance with correct properties', () => {
+    const binding = new KeyboardAxis1dBinding(
+      mockAction,
+      keyCodes.arrowRight,
+      keyCodes.arrowLeft,
+    );
+
+    expect(binding.action).toBe(mockAction);
+    expect(binding.positiveKeyCode).toBe(keyCodes.arrowRight);
+    expect(binding.negativeKeyCode).toBe(keyCodes.arrowLeft);
+  });
+
+  it('should set displayText based on the positive and negative key codes', () => {
+    const binding = new KeyboardAxis1dBinding(
+      mockAction,
+      keyCodes.d,
+      keyCodes.a,
+    );
+
+    expect(binding.displayText).toBe(`${keyCodes.a}, ${keyCodes.d} keys`);
+  });
+});

--- a/src/input/keyboard/bindings/keyboard-axis2d-binding.test.ts
+++ b/src/input/keyboard/bindings/keyboard-axis2d-binding.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { KeyboardAxis2dBinding } from './keyboard-axis2d-binding';
+import { Axis2dAction } from '../../actions';
+import { keyCodes } from '../../constants';
+
+describe('KeyboardAxis2dBinding', () => {
+  const mockAction: Axis2dAction = new Axis2dAction(
+    'testAxis2dAction',
+    'default',
+  );
+
+  it('should create an instance with correct properties', () => {
+    const binding = new KeyboardAxis2dBinding(
+      mockAction,
+      keyCodes.w,
+      keyCodes.s,
+      keyCodes.d,
+      keyCodes.a,
+    );
+
+    expect(binding.action).toBe(mockAction);
+    expect(binding.northKeyCode).toBe(keyCodes.w);
+    expect(binding.southKeyCode).toBe(keyCodes.s);
+    expect(binding.eastKeyCode).toBe(keyCodes.d);
+    expect(binding.westKeyCode).toBe(keyCodes.a);
+  });
+
+  it('should set displayText based on the four key codes', () => {
+    const binding = new KeyboardAxis2dBinding(
+      mockAction,
+      keyCodes.w,
+      keyCodes.s,
+      keyCodes.d,
+      keyCodes.a,
+    );
+
+    expect(binding.displayText).toBe(
+      `${keyCodes.w}, ${keyCodes.a}, ${keyCodes.s}, ${keyCodes.d} keys`,
+    );
+  });
+});

--- a/src/input/keyboard/input-sources/keyboard-input-source.test.ts
+++ b/src/input/keyboard/input-sources/keyboard-input-source.test.ts
@@ -2,8 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { KeyboardInputSource } from './keyboard-input-source';
 import { buttonMoments, keyCodes } from '../../constants';
 import { InputManager } from '../../input-manager';
-import { HoldAction, TriggerAction } from '../../actions';
-import { KeyboardHoldBinding, KeyboardTriggerBinding } from '../bindings';
+import {
+  Axis1dAction,
+  Axis2dAction,
+  HoldAction,
+  TriggerAction,
+} from '../../actions';
+import {
+  KeyboardAxis1dBinding,
+  KeyboardAxis2dBinding,
+  KeyboardHoldBinding,
+  KeyboardTriggerBinding,
+} from '../bindings';
 
 describe('KeyboardInputSource', () => {
   const group = 'default';
@@ -121,5 +131,84 @@ describe('KeyboardInputSource', () => {
     expect(keyHoldAction.isHeld).toBe(false);
     expect(holdStartEventHandler).not.toHaveBeenCalled();
     expect(holdEndEventHandler).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch key ups that are browser auto repeats', () => {
+    // see: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: keyCodes.a }));
+
+    window.dispatchEvent(
+      new KeyboardEvent('keyup', { code: keyCodes.a, repeat: true }),
+    );
+
+    expect(keyUpAction.isTriggered).toBe(false);
+  });
+
+  it('dispatches axis1d bindings on key down and key up', () => {
+    const axis1dAction = new Axis1dAction('axis1dAction', group);
+
+    inputManager.addAxis1dActions(axis1dAction);
+    source.axis1dBindings.add(
+      new KeyboardAxis1dBinding(axis1dAction, keyCodes.d, keyCodes.a),
+    );
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: keyCodes.d }));
+    expect(axis1dAction.value).toBe(1);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: keyCodes.a }));
+    expect(axis1dAction.value).toBe(0);
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: keyCodes.d }));
+    expect(axis1dAction.value).toBe(-1);
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: keyCodes.a }));
+    expect(axis1dAction.value).toBe(0);
+  });
+
+  it('dispatches axis2d bindings on key down and key up', () => {
+    const axis2dAction = new Axis2dAction('axis2dAction', group);
+
+    inputManager.addAxis2dActions(axis2dAction);
+    source.axis2dBindings.add(
+      new KeyboardAxis2dBinding(
+        axis2dAction,
+        keyCodes.w,
+        keyCodes.s,
+        keyCodes.d,
+        keyCodes.a,
+      ),
+    );
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: keyCodes.w }));
+    expect(axis2dAction.value.y).toBe(1);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: keyCodes.d }));
+    expect(axis2dAction.value.x).toBe(1);
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: keyCodes.w }));
+    expect(axis2dAction.value.y).toBe(0);
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: keyCodes.d }));
+    expect(axis2dAction.value.x).toBe(0);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: keyCodes.s }));
+    expect(axis2dAction.value.y).toBe(-1);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: keyCodes.a }));
+    expect(axis2dAction.value.x).toBe(-1);
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: keyCodes.s }));
+    expect(axis2dAction.value.y).toBe(0);
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: keyCodes.a }));
+    expect(axis2dAction.value.x).toBe(0);
+  });
+
+  it('stops dispatching after stop is called', () => {
+    source.stop();
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: keyCodes.a }));
+    expect(keyUpAction.isTriggered).toBe(false);
   });
 });

--- a/src/input/mouse/bindings/mouse-axis1d-binding.test.ts
+++ b/src/input/mouse/bindings/mouse-axis1d-binding.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { MouseAxis1dBinding } from './mouse-axis1d-binding';
+import { Axis1dAction } from '../../actions';
+
+describe('MouseAxis1dBinding', () => {
+  it('should create an instance with correct properties', () => {
+    const mockAction = new Axis1dAction('testAxis1dAction', 'default');
+    const binding = new MouseAxis1dBinding(mockAction);
+
+    expect(binding.action).toBe(mockAction);
+    expect(binding.displayText).toBe('mouse scroll');
+  });
+});

--- a/src/input/mouse/bindings/mouse-axis2d-binding.test.ts
+++ b/src/input/mouse/bindings/mouse-axis2d-binding.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { MouseAxis2dBinding } from './mouse-axis2d-binding';
+import { Axis2dAction } from '../../actions';
+import { cursorValueTypes } from '../../constants';
+
+describe('MouseAxis2dBinding', () => {
+  const mockAction = new Axis2dAction('testAxis2dAction', 'default');
+
+  it('should create an instance with default options', () => {
+    const binding = new MouseAxis2dBinding(mockAction);
+
+    expect(binding.action).toBe(mockAction);
+    expect(binding.displayText).toBe('mouse position');
+    expect(binding.cursorValueType).toBe(cursorValueTypes.ratio);
+    expect(binding.cursorOrigin).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it('should use the provided cursorValueType', () => {
+    const binding = new MouseAxis2dBinding(mockAction, {
+      cursorValueType: cursorValueTypes.absolute,
+    });
+
+    expect(binding.cursorValueType).toBe(cursorValueTypes.absolute);
+    expect(binding.cursorOrigin).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it('should use the provided cursorOrigin', () => {
+    const cursorOrigin = { x: 0, y: 1 };
+    const binding = new MouseAxis2dBinding(mockAction, { cursorOrigin });
+
+    expect(binding.cursorOrigin).toEqual(cursorOrigin);
+    expect(binding.cursorValueType).toBe(cursorValueTypes.ratio);
+  });
+});

--- a/src/input/mouse/input-sources/mouse-input-source.test.ts
+++ b/src/input/mouse/input-sources/mouse-input-source.test.ts
@@ -1,9 +1,19 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { MouseInputSource } from './mouse-input-source';
-import { buttonMoments, mouseButtons } from '../../constants';
+import { buttonMoments, cursorValueTypes, mouseButtons } from '../../constants';
 import { InputManager } from '../../input-manager';
-import { HoldAction, TriggerAction } from '../../actions';
-import { MouseHoldBinding, MouseTriggerBinding } from '../bindings';
+import {
+  Axis1dAction,
+  Axis2dAction,
+  HoldAction,
+  TriggerAction,
+} from '../../actions';
+import {
+  MouseAxis1dBinding,
+  MouseAxis2dBinding,
+  MouseHoldBinding,
+  MouseTriggerBinding,
+} from '../bindings';
 
 describe('MouseInputSource', () => {
   const group = 'default';
@@ -18,6 +28,14 @@ describe('MouseInputSource', () => {
   beforeEach(() => {
     container = document.createElement('div');
     document.body.appendChild(container);
+
+    container.getBoundingClientRect = () =>
+      ({
+        left: 100,
+        top: 50,
+        width: 200,
+        height: 100,
+      }) as DOMRect;
 
     inputManager = new InputManager();
     inputManager.setActiveGroup(group);
@@ -122,5 +140,108 @@ describe('MouseInputSource', () => {
 
     expect(holdAction.isHeld).toBe(true);
     expect(menuHoldAction.isHeld).toBe(false);
+  });
+
+  it('dispatches wheel events to axis1d bindings', () => {
+    const scrollAction = new Axis1dAction('scrollAction', group);
+
+    source.axis1dBindings.add(new MouseAxis1dBinding(scrollAction));
+
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: 50 }));
+
+    expect(scrollAction.value).toBe(0.5);
+  });
+
+  it('dispatches mouse move events to axis2d bindings using ratio values by default', () => {
+    const moveAction = new Axis2dAction('moveAction', group);
+
+    source.axis2dBindings.add(new MouseAxis2dBinding(moveAction));
+
+    // container is at (100, 50) and is 200x100, so clientX/Y of
+    // (200, 100) is 50% across and 50% down -> centered at the default
+    // (0.5, 0.5) origin.
+    container.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 200, clientY: 100 }),
+    );
+
+    expect(moveAction.value.x).toBeCloseTo(0);
+    expect(moveAction.value.y).toBeCloseTo(0);
+
+    container.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 300, clientY: 150 }),
+    );
+
+    expect(moveAction.value.x).toBeCloseTo(0.5);
+    expect(moveAction.value.y).toBeCloseTo(0.5);
+  });
+
+  it('dispatches mouse move events to axis2d bindings using absolute values', () => {
+    const moveAction = new Axis2dAction('moveAction', group);
+
+    source.axis2dBindings.add(
+      new MouseAxis2dBinding(moveAction, {
+        cursorValueType: cursorValueTypes.absolute,
+      }),
+    );
+
+    container.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 200, clientY: 100 }),
+    );
+
+    // (200 - 100) - 0.5 * 200 = 0, (100 - 50) - 0.5 * 100 = 0
+    expect(moveAction.value.x).toBeCloseTo(0);
+    expect(moveAction.value.y).toBeCloseTo(0);
+
+    container.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 250, clientY: 100 }),
+    );
+
+    expect(moveAction.value.x).toBeCloseTo(50);
+    expect(moveAction.value.y).toBeCloseTo(0);
+  });
+
+  it('throws when a binding has an unsupported cursor value type', () => {
+    const moveAction = new Axis2dAction('moveAction', group);
+    const binding = new MouseAxis2dBinding(moveAction);
+
+    // @ts-expect-error deliberately assigning an invalid cursor value type
+    binding.cursorValueType = 'unsupported';
+
+    source.axis2dBindings.add(binding);
+
+    // The DOM spec doesn't propagate exceptions thrown inside event
+    // listeners back to `dispatchEvent`'s caller, so the private handler is
+    // invoked directly here to observe the throw.
+    const onMouseMoveHandler = (
+      source as unknown as Record<string, (event: MouseEvent) => void>
+    )['_onMouseMoveHandler'];
+
+    expect(() =>
+      onMouseMoveHandler(
+        new MouseEvent('mousemove', { clientX: 200, clientY: 100 }),
+      ),
+    ).toThrow('Unsupported cursor value type: unsupported');
+  });
+
+  it('clears button state on reset', () => {
+    container.dispatchEvent(
+      new MouseEvent('mousedown', { button: mouseButtons.left }),
+    );
+    expect(clickDownAction.isTriggered).toBe(true);
+
+    source.reset();
+
+    inputManager.reset();
+    expect(clickDownAction.isTriggered).toBe(false);
+  });
+
+  it('stops dispatching after stop is called', () => {
+    source.stop();
+
+    container.dispatchEvent(
+      new MouseEvent('mousedown', { button: mouseButtons.left }),
+    );
+
+    expect(clickDownAction.isTriggered).toBe(false);
   });
 });

--- a/src/input/register-inputs.test.ts
+++ b/src/input/register-inputs.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { registerInputs } from './register-inputs';
+import { EcsWorld } from '../ecs';
+import { Time } from '../common';
+import { inputsId } from './components/index.js';
+import { InputManager } from './input-manager';
+import {
+  Axis1dAction,
+  Axis2dAction,
+  HoldAction,
+  TriggerAction,
+} from './actions/index.js';
+
+describe('registerInputs', () => {
+  let world: EcsWorld;
+  let time: Time;
+
+  beforeEach(() => {
+    world = new EcsWorld();
+    time = new Time();
+  });
+
+  it('returns an InputManager', () => {
+    const inputManager = registerInputs(world, time);
+
+    expect(inputManager).toBeInstanceOf(InputManager);
+  });
+
+  it('attaches the InputManager to a new entity in the world', () => {
+    const inputManager = registerInputs(world, time);
+
+    const entities = world.query([inputsId]).entities;
+
+    expect(entities).toHaveLength(1);
+    expect(world.getComponent(entities[0], inputsId)?.inputManager).toBe(
+      inputManager,
+    );
+  });
+
+  it('registers actions passed in options with the InputManager', () => {
+    const triggerAction = new TriggerAction('trigger', 'default');
+    const axis1dAction = new Axis1dAction('axis1d', 'default');
+    const axis2dAction = new Axis2dAction('axis2d', 'default');
+    const holdAction = new HoldAction('hold', 'default');
+
+    const inputManager = registerInputs(world, time, {
+      triggerActions: [triggerAction],
+      axis1dActions: [axis1dAction],
+      axis2dActions: [axis2dAction],
+      holdActions: [holdAction],
+    });
+
+    expect(inputManager.getTriggerAction('trigger')).toBe(triggerAction);
+    expect(inputManager.getAxis1dAction('axis1d')).toBe(axis1dAction);
+    expect(inputManager.getAxis2dAction('axis2d')).toBe(axis2dAction);
+    expect(inputManager.getHoldAction('hold')).toBe(holdAction);
+  });
+
+  it('registers update and reset systems that drive the InputManager each tick', () => {
+    const triggerAction = new TriggerAction('trigger', 'game');
+
+    const inputManager = registerInputs(world, time, {
+      triggerActions: [triggerAction],
+    });
+
+    inputManager.setActiveGroup('game');
+    triggerAction.trigger();
+    expect(triggerAction.isTriggered).toBe(true);
+
+    time.update(16);
+    world.update();
+
+    expect(triggerAction.isTriggered).toBe(false);
+  });
+
+  it('does not throw when called without options', () => {
+    expect(() => registerInputs(world, time)).not.toThrow();
+  });
+});

--- a/src/input/systems/reset-inputs-system.test.ts
+++ b/src/input/systems/reset-inputs-system.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createResetInputsEcsSystem } from './reset-inputs-system';
+import { EcsWorld } from '../../ecs';
+import { addInputsComponent } from '../components/inputs-component';
+import { InputManager } from '../input-manager';
+
+describe('createResetInputsEcsSystem', () => {
+  let world: EcsWorld;
+
+  beforeEach(() => {
+    world = new EcsWorld();
+    world.addSystem(createResetInputsEcsSystem());
+  });
+
+  it('resets the input manager', () => {
+    const entity = world.createEntity();
+    const inputManager = new InputManager();
+
+    addInputsComponent(world, entity, { inputManager });
+
+    const resettable = { reset: vi.fn() };
+
+    inputManager.addResettable(resettable);
+
+    world.update();
+
+    expect(resettable.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets every inputs component independently', () => {
+    const entity1 = world.createEntity();
+    const entity2 = world.createEntity();
+
+    const inputManager1 = new InputManager();
+    const inputManager2 = new InputManager();
+
+    addInputsComponent(world, entity1, { inputManager: inputManager1 });
+    addInputsComponent(world, entity2, { inputManager: inputManager2 });
+
+    const resettable1 = { reset: vi.fn() };
+    const resettable2 = { reset: vi.fn() };
+
+    inputManager1.addResettable(resettable1);
+    inputManager2.addResettable(resettable2);
+
+    world.update();
+
+    expect(resettable1.reset).toHaveBeenCalledTimes(1);
+    expect(resettable2.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when no entity has an inputs component', () => {
+    expect(() => world.update()).not.toThrow();
+  });
+});

--- a/src/input/systems/update-inputs-system.test.ts
+++ b/src/input/systems/update-inputs-system.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createUpdateInputEcsSystem } from './update-inputs-system';
+import { EcsWorld } from '../../ecs';
+import { Time } from '../../common';
+import { addInputsComponent } from '../components/inputs-component';
+import { InputManager } from '../input-manager';
+
+describe('createUpdateInputEcsSystem', () => {
+  let world: EcsWorld;
+  let time: Time;
+
+  beforeEach(() => {
+    world = new EcsWorld();
+    time = new Time();
+    world.addSystem(createUpdateInputEcsSystem(time));
+  });
+
+  it('updates the input manager with the elapsed delta time', () => {
+    const entity = world.createEntity();
+    const inputManager = new InputManager();
+
+    addInputsComponent(world, entity, { inputManager });
+
+    const updatable = { update: vi.fn() };
+
+    inputManager.addUpdatable(updatable);
+
+    time.update(100);
+    time.update(150);
+    world.update();
+
+    expect(updatable.update).toHaveBeenCalledWith(time.deltaTimeInMilliseconds);
+  });
+
+  it('updates every inputs component independently', () => {
+    const entity1 = world.createEntity();
+    const entity2 = world.createEntity();
+
+    const inputManager1 = new InputManager();
+    const inputManager2 = new InputManager();
+
+    addInputsComponent(world, entity1, { inputManager: inputManager1 });
+    addInputsComponent(world, entity2, { inputManager: inputManager2 });
+
+    const updatable1 = { update: vi.fn() };
+    const updatable2 = { update: vi.fn() };
+
+    inputManager1.addUpdatable(updatable1);
+    inputManager2.addUpdatable(updatable2);
+
+    time.update(100);
+    world.update();
+
+    expect(updatable1.update).toHaveBeenCalledTimes(1);
+    expect(updatable2.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when no entity has an inputs component', () => {
+    expect(() => {
+      time.update(100);
+      world.update();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds tests for files under `src/input` that previously had no coverage:
  `register-inputs.ts`, the `update-inputs-system.ts`/`reset-inputs-system.ts`
  ECS systems, and the keyboard/mouse axis-1d/axis-2d bindings.
- Fills in previously-missed branches in `input-manager.ts` (add/remove/get
  actions, hold dispatch regardless-of-group behavior), the action classes
  (`Axis1dAction`, `Axis2dAction`, `HoldAction`, `TriggerAction` — default
  input group, `noReset` reset type, change-event raising), and the
  keyboard/mouse/gamepad input sources (wheel/mousemove handling, `stop()`/
  `reset()`, repeat-key guards, gamepad reconnection, and edge-case
  axis/button value reads).
- No production code changed — this PR is test-only.

Every file under `src/input` is now at 100% statement/branch/function
coverage, with one exception: a defensive `?? 0` fallback in
`gamepad-input-source.ts` that's unreachable given how the surrounding code
populates its map, left uncovered rather than forcing an artificial test.

## Related issue(s)

N/A

## Verification checklist

- [x] `npm run check-types` passes with 0 errors
- [x] `npm test` passes (1042 tests)
- [x] `npm run lint` passes with 0 errors
- [x] `npm run cspell` passes with 0 errors
- [x] `npm run check-exports` passes
- [x] Any new/changed public API is exported from the module's `index.ts`
      (and `/src/index.ts` / `package.json` `exports` if it's a new module) —
      N/A, no public API changes
- [x] Documentation under `/documentation-site/docs/docs` is updated if this
      change affects documented behavior — N/A, no behavior changes
- [x] If this change touches a module with a demo under
      `/documentation-site/src/pages/demos`, the demo has been updated and
      verified — N/A, no API/behavior changes for demos to pick up

## Changelog

- [x] Not required — this PR's Conventional Commits type is `test`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016CEcLtRhi2VKrWQKgnNxRC)_