### PR TITLE
docs(agents): correct input capability list in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Forge is a browser-based, code-only game engine built with TypeScript. It provid
 - **Physics**: Native 2D physics engine (rigid bodies, collision detection/resolution, gravity)
 - **Audio**: Sound management via Howler.js
 - **Animations**: Robust animation system
-- **Input**: Keyboard, mouse, and touch input handling
+- **Input**: Keyboard, mouse, and gamepad input handling
 - **Particles**: Particle system
 - **Asset Loading**: Resource management
 - **FSM**: Finite state machine implementation


### PR DESCRIPTION
## Summary

`AGENTS.md`'s Project Overview listed the engine's input capabilities as "Keyboard, mouse, and touch input handling". `src/input/` has keyboard, mouse, and **gamepad** input sources — there is no `TouchInputSource`. Corrected the line to say "Keyboard, mouse, and gamepad input handling".

While in there, audited the rest of the Project Overview list against `/src`: ECS, rendering (WebGL2), physics (rigid bodies, collision, gravity), audio (Howler.js), animations, particles, asset loading, and FSM all match their implementations — no further drift found. Also checked `README.md` and `documentation-site/docs` for the same "touch" claim; neither duplicates it, so no other file needed a change.

This is documentation-only; no `TouchInputSource` was added (that's explicitly out of scope per the issue).

## Related issue(s)

Closes #582

## Verification checklist

- [x] `npm run check-types` passes with 0 errors (no `/src` changes made)
- [x] `npm test` passes (no `/src` changes made)
- [x] `npm run lint` passes with 0 errors
- [x] `npm run cspell` passes with 0 errors
- [x] `npm run check-exports` passes (no `/src` changes made)
- [x] Any new/changed public API is exported from the module's `index.ts` — N/A, no API change
- [x] Documentation under `/documentation-site/docs/docs` is updated if this change affects documented behavior — N/A, no documented behavior changed, `AGENTS.md` itself is the doc being corrected
- [x] If this change touches a module with a demo — N/A, no `/src` module touched

## Changelog

- [x] Not required — Conventional Commits type is `docs`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Au71RknwApwJKmk1t2MD9h)_