### PR TITLE
docs: Add design skill

### DIFF
--- a/.claude/skills/add-feature-demo/SKILL.md
+++ b/.claude/skills/add-feature-demo/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: add-demo
-description: Decide whether a change needs a new interactive demo under documentation-site/src/pages/demos, and if so scaffold and wire it up (page, navbar dropdown entry, code-viewer files). Use when adding a new major engine feature or module, or when explicitly asked to add a demo.
+name: add-feature-demo
+description: Use this skill when adding a new feature to the engine.
 ---
 
 # Add a Demo
@@ -17,28 +17,20 @@ existing.
 **Every new major feature gets a demo.** A major feature is a new `/src`
 module (a new top-level directory under `/src` with its own `package.json`
 export, e.g. `physics`, `particles`), or a substantial new capability added
-to an existing module that a user couldn't do before (a new joint type, a
-new rendering effect, a new component category with its own systems) —
-the kind of thing that gets its own line in `CHANGELOG.md`'s `#### Added`,
-not a `#### Fixed` or `#### Changed` tweak to something already
-demonstrated.
+to an existing module that a user couldn't do before.
 
 Skip a new demo for:
 
 - Bug fixes, performance improvements, or refactors to something an
   existing demo already exercises — that demo continues to cover it (though
   see step 5 if the change altered the demo's API surface).
-- Internal-only APIs with no visible behavior (a new utility function, a
-  type export, an ECS plumbing change) — nothing to show on a canvas.
+- Internal-only APIs with no visible behavior.
 - A small option/parameter added to an already-demoed feature — extend the
   existing demo instead of creating a new one, unless the option is
-  significant enough to need its own dedicated scene to be legible (compare
-  how `revolute-joint`, `prismatic-joint`, and `torque` are three separate
-  physics demos rather than one crowded one).
+  significant enough to need its own dedicated scene to be legible.
 
 If genuinely unsure whether a change counts as "major," ask the user rather
-than guessing — an unwanted demo is wasted scaffolding, a missing one is a
-silent documentation gap.
+than guessing.
 
 ## 2. Pick a name and scaffold the directory
 

--- a/.claude/skills/create-design-document/SKILL.md
+++ b/.claude/skills/create-design-document/SKILL.md
@@ -47,4 +47,6 @@ When constructing a design document. Never assume that the business wants a "qui
 
 Forge is it's own unique product, do not use wording, or text that are common place in a competitor's product. The design document should be written in a way that is clear and concise, and should avoid using jargon or buzzwords that are not relevant to the design.
 
-If there is any uncertainty or ambiguity during the design phase as to the direction of the product of the intention of the feature, as the user. 
+If there is any uncertainty or ambiguity during the design phase as to the direction of the product of the intention of the feature, as the user.
+
+If a large is being requested for design. Consider breaking it down into smaller pieces and suggesting a phased approach to the design to the user.

--- a/.claude/skills/create-design-document/SKILL.md
+++ b/.claude/skills/create-design-document/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: create-design-document
+description: Use this skill when designing or planning for a new feature or major change to the engine.
+---
+
+# Design a feature
+
+The `design` folder holds design documents and specifications for new features, major re-writes and refactors to the engine.
+Consult the `AGENTS.md` for information on how the engine is structured and works before starting planning.
+
+## 1. Document Structure
+
+Every design document should be a markdown file in the `design` folder. The file name should be descriptive of the feature being designed, and should be in kebab-case (e.g. `new-feature.md`).
+
+In the document, include the following sections:
+
+- Name: A short, descriptive name for the feature, re-write or refactor.
+- A table that lists: 
+  - the targeted modules, indicating which are new, which are being modified, and which are being removed.
+  - Engine version at time of design
+- Summary: A brief summary of the feature, re-write or refactor, that briefly includes its purpose and goals.
+- Scope
+  - In scope: A list of the specific features, modules, or components that will be included in the design.
+  - Out of scope: A list of the specific features, modules, or components that will not be in the design, that one may assume would be included, but are not.
+- Phases: A list of the phases of the design, including a brief description of each phase and its goals, a table of task that need to be implemented in each phase. Each task should have a name, a description, and a T-shit size estimate (S, M, L, XL). Phases should be pieces of work that need to happen in order to complete the design, and should be ordered in a logical sequence. Each phase should have a clear definition of done, and should be able to be completed and released independently of other phases.
+- A decision log: A list of the major decisions made during the design process, including the possible options, the decision (which option was chosen), and the rationale behind it, the tradeoff and assumptions made.
+- A list of open questions: A list of the open questions that need to be answered in order to complete the design, including the question, the possible options, and the rationale behind each option. The list should be ordered by priority, with the most important questions at the top.
+- Design sub-sections: An arbitrary number of sections that describe major parts of the design, include anything that is relevant to the design, including but not limited to: 
+  - API design
+  - Data structures
+  - Algorithms
+  - Performance considerations
+  - Security considerations
+  - User experience considerations
+  - Accessibility considerations
+  - Internationalization considerations
+  - Testing considerations
+  - Documentation considerations
+  - Entity composition and relationships
+  - Mermaid diagrams
+  - Pseudocode
+  - Toolchains and pipelines
+
+## 2. Design considerations
+
+When constructing a design document. Never assume that the business wants a "quick fix" or "hack" to a problem. Just because something might "take a lot of work", or will be a "big change" does not mean it is not the right solution. The design document should be a complete and thorough exploration of the problem space, and should consider all possible solutions, even if they are not the most obvious or easiest to implement.
+
+Forge is it's own unique product, do not use wording, or text that are common place in a competitor's product. The design document should be written in a way that is clear and concise, and should avoid using jargon or buzzwords that are not relevant to the design.
+
+If there is any uncertainty or ambiguity during the design phase as to the direction of the product of the intention of the feature, as the user. 


### PR DESCRIPTION
## Summary

<!-- Describe what this change does and why. -->

## Related issue(s)

<!-- e.g. Closes #123 -->

## Verification checklist

<!-- See CONTRIBUTING.md and CLAUDE.md for details on each step. -->

- [ ] `npm run check-types` passes with 0 errors
- [ ] `npm test` passes
- [ ] `npm run lint` passes with 0 errors
- [ ] `npm run cspell` passes with 0 errors
- [ ] `npm run check-exports` passes
- [ ] Any new/changed public API is exported from the module's `index.ts`
      (and `/src/index.ts` / `package.json` `exports` if it's a new module)
- [ ] Documentation under `/documentation-site/docs/docs` is updated if this
      change affects documented behavior
- [ ] If this change touches a module with a demo under
      `/documentation-site/src/pages/demos`, the demo has been updated and
      verified (see AGENTS.md's "Documentation Site Demos" section)

## Changelog

- [ ] A bullet has been added under `## [Unreleased]` in `CHANGELOG.md`
      (required unless this PR's Conventional Commits type is `chore`,
      `style`, `refactor`, `test`, `ci`, `docs`, or `build` — see
      AGENTS.md's "Changelog" section)
