### PR TITLE
feat(text): add MSDF font atlas generation, format, and loading (phase 1)

### DIFF
--- a/.claude/skills/document-feature/SKILL.md
+++ b/.claude/skills/document-feature/SKILL.md
@@ -43,17 +43,63 @@ does that). Favor:
   realistic scenario, e.g. "use `applyForce` for a continuous push like
   wind or thrust, use `applyImpulse` for an instantaneous hit like a
   collision or jump."
-- **Gotchas**: non-obvious behavior, ordering requirements (e.g. system
-  registration order), units and coordinate conventions, what happens at
-  edge values (zero mass, disabled entities, static bodies, etc.).
-- **Performance notes**: anything that affects cost at scale, caching
-  behavior, when an optimization kicks in or is bypassed, what to avoid
-  doing every frame. Mine recent perf-related commits and code comments for
-  this.
+- **Gotchas**: non-obvious behavior the reader's own code must account for,
+  e.g. ordering requirements (system registration order), units and
+  coordinate conventions, what a lookup returns at edge values (a miss
+  returns `undefined` rather than throwing; a disabled entity is skipped).
+  The test is whether it changes what code the reader writes, not whether
+  it's interesting.
+- **Performance notes**: anything that affects cost at scale and changes
+  what the reader should do, e.g. "preload up front, not mid-gameplay."
+  Mine recent perf-related commits and code comments for this, but state
+  the actionable consequence, not the mechanism.
 - **Common mistakes / code smells**: a short "don't do this" example paired
   with "do this instead" and a one-line reason.
 - **A realistic worked example**: the feature used in context (inside a
   system, alongside related components), not just a bare constructor call.
+
+### Tone: factual, not narrative
+
+Write declarative sentences a reader can scan for the fact they need, not
+prose that reassures or editorializes. Cut adjectives/adverbs that describe
+quality rather than behavior ("gracefully", "cleanly", "nicely",
+"powerful", "simply", "just") — if a sentence still means the same thing
+with the adjective removed, remove it. State what happens; don't comment on
+how good the way it happens is.
+
+### Document the interface, not the internals
+
+The reader needs to know what the feature does from the outside: inputs,
+outputs, return values, when a promise rejects, what triggers a thrown
+error. They do not need _how_ it's implemented internally, and they do not
+need reassurance about implementation quality:
+
+- Wrong: "`load` rejects with a descriptive error if the JSON is malformed,
+  so a broken file never surfaces as a confusing `NaN` downstream." (this
+  narrates an internal design decision and vouches for its own quality)
+- Right: nothing at all, if the mere fact that malformed input throws isn't
+  something the reader has to code around. If it genuinely changes what the
+  reader should do (e.g. "wrap `load` in try/catch when the source isn't
+  your own build output"), say that specific, actionable thing and stop.
+
+The same applies to caching mechanics, internal data structures, or how an
+error is caught and re-thrown: these are implementation facts you likely
+learned while building the feature, not things the reader needs.
+
+### Only cross-link genuine is-a relationships
+
+Link to a shared parent concept the feature is a real instance of (a
+specific `AssetCache` implementation → the `AssetCache` doc), since the
+reader benefits from knowing the general contract once. Do **not** link to
+or mention a sibling/adjacent feature just because it's similar, reuses the
+same pattern, or was what you read as an implementation reference while
+building this one (e.g. don't mention `ImageCache` while documenting a new,
+unrelated cache just because you modeled the new cache's code after it).
+Citing a sibling assumes the reader already knows that sibling — usually
+false — and adds cognitive load for no payoff. Before adding any
+cross-reference, ask: would a reader who has never seen the other thing
+still get full value from this link? If the answer is "they'd have to go
+learn the other thing first," cut it.
 
 ### What does NOT belong in the guide
 
@@ -61,6 +107,13 @@ does that). Favor:
   API reference instead.
 - A "Properties" section that just restates field declarations.
 - Method-by-method walkthroughs that mirror the class's public interface.
+- Implementation narration: how errors are caught internally, how caching
+  is implemented under the hood, why an internal design choice was made.
+- A "Guides in this section" list on a module's `index.md` if the sidebar
+  nav already lists those same pages — it's pure duplication.
+- Reassurance that the engine does its job well ("fails descriptively",
+  "handles this gracefully"). State the observable behavior; skip the
+  editorializing about how well it's done.
 
 If you find yourself transcribing JSDoc into the guide, stop, that
 information already lives in the generated reference. Link to it using the
@@ -80,8 +133,10 @@ Guide pages live at `documentation-site/docs/docs/<module>/<topic>.md`, where
   feature is a small addition to a concept already documented there.
 - **Module folder doesn't exist yet**: create it with:
   - `_category_.json`
-  - `index.md`, short overview of the module (1+ paragraphs, optionally a
-    bullet list of "Guides in this section" linking to each page)
+  - `index.md`, a short overview of the module (1+ paragraphs). Don't add a
+    "Guides in this section" list of links to the other pages in the
+    folder — the sidebar nav already lists them; a manual list is pure
+    duplication that goes stale the moment a page is renamed.
   - the new topic page(s)
 
 ### Page conventions
@@ -128,8 +183,6 @@ to pick a `position` that doesn't collide.
 
 ## 5. Wire it up
 
-- If the module's `index.md` has a "Guides in this section" list, add the
-  new page to it.
 - Double-check the new page's filename/heading reads sensibly in the
   autogenerated sidebar (`docsSidebar` uses `{ type: 'autogenerated', dirName: '.' }`).
 

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -19,6 +19,7 @@ blits
 bmfont
 cachable
 Catmull
+charsets
 Chlumský
 commitlint
 Cramer

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -16,6 +16,7 @@ Baumgarte
 Beziers
 blit
 blits
+bmfont
 cachable
 Catmull
 Chlumský
@@ -61,6 +62,7 @@ interactable
 interactables
 Kenney
 kenneynl
+kernings
 keyup
 Killst
 lerp
@@ -151,5 +153,6 @@ Vleugels
 WASD
 webgl
 Wenrexa
+xadvance
 yoavbls
 Zoltan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Forge is a browser-based, code-only game engine built with TypeScript. It provid
   /physics                 # Physics integration
   /pooling                 # Object pooling
   /rendering               # Rendering system
+  /text                    # MSDF font atlas loading and (eventually) text rendering
   /timer                   # Timer utilities
   /utilities               # General utilities
   index.ts                 # Main exports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+- **text:** Add `@forge-game-engine/forge/text`'s font atlas pipeline (Phase 1 of MSDF text rendering, no rendering yet): `npm run generate-font-atlas` turns a `.ttf`/`.otf` font into a multi-channel signed distance field (MSDF) atlas PNG plus a versioned `FontAtlasData` JSON, and `FontAtlasCache` loads that pair into a `FontAtlas` at runtime
 - **physics:** Add `raycast(world, start, end, sort?)`, casting a line segment against every entity in an `EcsWorld` with a `ColliderEcsComponent` (`CircleCollider`, `PolygonCollider`, and `TerrainCollider` alike) and returning every intersection as a `RaycastHit` (`entity`, `point`, `normal`, `distance`), ordered by distance from `start` by default
 - **physics:** Add `RigidBodyEcsComponent.type` (`'dynamic'` | `'kinematic'` | `'static'`, defaulting to `'dynamic'`), letting a body be moved directly by game code (`'kinematic'`) so it still pushes dynamic bodies on contact without itself being affected by gravity, forces, or impulses - previously only possible implicitly, by giving an entity no `RigidBodyEcsComponent` at all (still supported, and equivalent to `type: 'static'`)
 

--- a/documentation-site/docs/docs/asset-loading/index.md
+++ b/documentation-site/docs/docs/asset-loading/index.md
@@ -6,15 +6,16 @@ sidebar_position: 5
 
 Asset loading covers fetching external files (images, sprite sheets,
 sounds, data) and turning them into objects your game can use, then caching
-the results so the same file is never fetched twice. Forge ships one
-concrete cache today, [`ImageCache`](/Forge/docs/api/classes/ImageCache),
-plus two supporting building blocks:
+the results so the same file is never fetched twice. Forge ships two
+concrete caches today, [`ImageCache`](/Forge/docs/api/classes/ImageCache)
+and [`FontAtlasCache`](/Forge/docs/api/classes/FontAtlasCache) (see
+[Text](../text/index.md)), plus two supporting building blocks:
 
 - [`AssetCache`](/Forge/docs/api/interfaces/AssetCache): the common
   `get` / `load` / `getOrLoad` contract that asset caches implement.
-  `ImageCache` implements it for `HTMLImageElement`; if you add a cache for
-  another asset type (audio buffers, JSON data, fonts), implement this
-  interface so it behaves consistently with the rest of the engine.
+  `ImageCache` and `FontAtlasCache` both implement it; if you add a cache
+  for another asset type (audio buffers, arbitrary JSON data), implement
+  this interface so it behaves consistently with the rest of the engine.
 - [`AssetRegistry`](/Forge/docs/api/classes/AssetRegistry): maps
   human-readable string IDs to compact numeric IDs, so hot-path code (like a
   per-frame animation system) can look up an asset by index instead of by

--- a/documentation-site/docs/docs/text/_category_.json
+++ b/documentation-site/docs/docs/text/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Text",
+  "position": 11,
+  "link": {
+    "type": "doc",
+    "id": "docs/text/index"
+  }
+}

--- a/documentation-site/docs/docs/text/generating-a-font-atlas.md
+++ b/documentation-site/docs/docs/text/generating-a-font-atlas.md
@@ -16,15 +16,19 @@ something your game runs at runtime.
 The command wraps [`msdf-bmfont-xml`](https://www.npmjs.com/package/msdf-bmfont-xml),
 an **optional peer dependency** of `@forge-game-engine/forge`. A plain
 `npm install @forge-game-engine/forge` does not install it, since most games
-don't need the atlas generator itself, only its output. Install it once,
-as a dev dependency of your own project:
+don't need the atlas generator itself, only its output. Install it as a dev
+dependency of your project:
 
 ```bash
 npm install --save-dev msdf-bmfont-xml
 ```
 
-Running the command without it installed fails fast with a message telling
-you to install it, rather than a raw module-not-found error.
+Or, since most games never need it at runtime and only run it occasionally,
+install it globally instead:
+
+```bash
+npm install -g msdf-bmfont-xml
+```
 
 ## Generate an atlas
 
@@ -32,20 +36,19 @@ you to install it, rather than a raw module-not-found error.
 npx forge-generate-font-atlas --font my-font.ttf --charset ascii --out assets/fonts/my-font
 ```
 
-This writes `assets/fonts/my-font.png` and `assets/fonts/my-font.json`.
-Commit both to your project; [`FontAtlasCache`](./loading-a-font-atlas.md)
-loads them together at runtime.
+This writes `assets/fonts/my-font.png` and `assets/fonts/my-font.json`, which
+[`FontAtlasCache`](./loading-a-font-atlas.md) loads together at runtime.
 
-| Flag                             | Default   | Meaning                                                                                                 |
-| --------------------------------- | --------- | --------------------------------------------------------------------------------------------------------- |
-| `--font <path>`                   | required  | The input `.ttf`/`.otf` file.                                                                              |
-| `--out <path>`                    | required  | Output path with no extension; writes `<out>.png` and `<out>.json`.                                        |
-| `--charset <name\|string\|path>`  | `ascii`   | `ascii` for printable ASCII (32-126), a literal string of characters, or a path to a text file to read them from. |
-| `--size <n>`                      | `42`      | The font size, in pixels, the distance field is authored at.                                               |
-| `--distance-range <n>`            | `4`       | The distance field's encoded range, in pixels.                                                             |
-| `--texture-width <n>`             | `512`     | Atlas texture width, in pixels.                                                                            |
-| `--texture-height <n>`            | `512`     | Atlas texture height, in pixels.                                                                           |
-| `--help`, `-h`                    |           | Print usage.                                                                                                |
+| Flag                             | Default  | Meaning                                                                                                           |
+| -------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `--font <path>`                  | required | The input `.ttf`/`.otf` file.                                                                                     |
+| `--out <path>`                   | required | Output path with no extension; writes `<out>.png` and `<out>.json`.                                               |
+| `--charset <name\|string\|path>` | `ascii`  | `ascii` for printable ASCII (32-126), a literal string of characters, or a path to a text file to read them from. |
+| `--size <n>`                     | `42`     | The font size, in pixels, the distance field is authored at.                                                      |
+| `--distance-range <n>`           | `4`      | The distance field's encoded range, in pixels.                                                                    |
+| `--texture-width <n>`            | `512`    | Atlas texture width, in pixels.                                                                                   |
+| `--texture-height <n>`           | `512`    | Atlas texture height, in pixels.                                                                                  |
+| `--help`, `-h`                   |          | Print usage.                                                                                                      |
 
 ## Picking a charset
 
@@ -75,11 +78,3 @@ with an error telling you to reduce the charset or increase
 glyphs across multiple pages. Multi-page atlases aren't supported: every
 `FontAtlas` maps to exactly one texture, so a `FontAtlasCache` lookup never
 needs to bind more than one image per font.
-
-## Regenerating after a font or charset change
-
-The output JSON is fully derived from the input font and flags, there's
-nothing to hand-edit. If your game later needs a character the atlas
-doesn't have (a new supported language, an added symbol), re-run the same
-command with an updated `--charset` and commit the new `.png`/`.json` pair;
-there's no incremental update path.

--- a/documentation-site/docs/docs/text/generating-a-font-atlas.md
+++ b/documentation-site/docs/docs/text/generating-a-font-atlas.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 1
+---
+
+# Generating a Font Atlas
+
+`forge-generate-font-atlas` is an offline command that turns a `.ttf`/`.otf`
+font into an MSDF atlas: `<out>.png` (the atlas texture) and `<out>.json`
+(the glyph metrics, in Forge's own
+[`FontAtlasData`](/Forge/docs/api/interfaces/FontAtlasData) shape). It's a
+build-time step, run once whenever your font or charset changes, not
+something your game runs at runtime.
+
+## Install the generator
+
+The command wraps [`msdf-bmfont-xml`](https://www.npmjs.com/package/msdf-bmfont-xml),
+an **optional peer dependency** of `@forge-game-engine/forge`. A plain
+`npm install @forge-game-engine/forge` does not install it, since most games
+don't need the atlas generator itself, only its output. Install it once,
+as a dev dependency of your own project:
+
+```bash
+npm install --save-dev msdf-bmfont-xml
+```
+
+Running the command without it installed fails fast with a message telling
+you to install it, rather than a raw module-not-found error.
+
+## Generate an atlas
+
+```bash
+npx forge-generate-font-atlas --font my-font.ttf --charset ascii --out assets/fonts/my-font
+```
+
+This writes `assets/fonts/my-font.png` and `assets/fonts/my-font.json`.
+Commit both to your project; [`FontAtlasCache`](./loading-a-font-atlas.md)
+loads them together at runtime.
+
+| Flag                             | Default   | Meaning                                                                                                 |
+| --------------------------------- | --------- | --------------------------------------------------------------------------------------------------------- |
+| `--font <path>`                   | required  | The input `.ttf`/`.otf` file.                                                                              |
+| `--out <path>`                    | required  | Output path with no extension; writes `<out>.png` and `<out>.json`.                                        |
+| `--charset <name\|string\|path>`  | `ascii`   | `ascii` for printable ASCII (32-126), a literal string of characters, or a path to a text file to read them from. |
+| `--size <n>`                      | `42`      | The font size, in pixels, the distance field is authored at.                                               |
+| `--distance-range <n>`            | `4`       | The distance field's encoded range, in pixels.                                                             |
+| `--texture-width <n>`             | `512`     | Atlas texture width, in pixels.                                                                            |
+| `--texture-height <n>`            | `512`     | Atlas texture height, in pixels.                                                                           |
+| `--help`, `-h`                    |           | Print usage.                                                                                                |
+
+## Picking a charset
+
+Only include the characters your game actually displays. A charset of every
+printable ASCII character comfortably fits a default 512x512 atlas for most
+fonts; adding a full Unicode range (accented Latin, Cyrillic, CJK) does not
+and pushes the atlas texture much larger for glyphs you may never draw. For
+a menu that only ever shows uppercase letters and digits, pass a literal
+charset instead of the `ascii` preset:
+
+```bash
+npx forge-generate-font-atlas --font heading.ttf --charset "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" --out assets/fonts/heading
+```
+
+Or point `--charset` at a text file if the character list is long or shared
+across multiple fonts:
+
+```bash
+npx forge-generate-font-atlas --font body.ttf --charset ./charsets/latin-extended.txt --out assets/fonts/body
+```
+
+## Only one atlas page is supported
+
+If a charset doesn't fit in the requested texture size, generation fails
+with an error telling you to reduce the charset or increase
+`--texture-width`/`--texture-height`, rather than silently splitting the
+glyphs across multiple pages. Multi-page atlases aren't supported: every
+`FontAtlas` maps to exactly one texture, so a `FontAtlasCache` lookup never
+needs to bind more than one image per font.
+
+## Regenerating after a font or charset change
+
+The output JSON is fully derived from the input font and flags, there's
+nothing to hand-edit. If your game later needs a character the atlas
+doesn't have (a new supported language, an added symbol), re-run the same
+command with an updated `--charset` and commit the new `.png`/`.json` pair;
+there's no incremental update path.

--- a/documentation-site/docs/docs/text/index.md
+++ b/documentation-site/docs/docs/text/index.md
@@ -35,7 +35,7 @@ npx forge-generate-font-atlas --font my-font.ttf --charset ascii --out assets/fo
 import { FontAtlasCache } from '@forge-game-engine/forge/text';
 
 const fontAtlasCache = new FontAtlasCache();
-const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font.json');
 
 console.log(fontAtlas.data.glyphs.get('A'.codePointAt(0)!));
 ```

--- a/documentation-site/docs/docs/text/index.md
+++ b/documentation-site/docs/docs/text/index.md
@@ -11,14 +11,6 @@ render size (12px or 400px, zoomed in or out) without regenerating anything,
 because the texture stores each glyph's distance-to-edge rather than a fixed
 raster of pixels.
 
-:::info
-This module currently covers **generating and loading** a font atlas only.
-There is no `TextEcsComponent`, no text shaping, and no draw path yet, so
-you can't render text on screen with it. If you need on-screen text today,
-render it to a canvas texture yourself or overlay DOM on top of the game
-canvas. This page will be updated once rendering lands.
-:::
-
 Two pieces make up the pipeline:
 
 - An offline command, `forge-generate-font-atlas`, that reads a font file
@@ -28,16 +20,9 @@ Two pieces make up the pipeline:
 - [`FontAtlasCache`](/Forge/docs/api/classes/FontAtlasCache), which loads
   that JSON/image pair at runtime into a
   [`FontAtlas`](/Forge/docs/api/interfaces/FontAtlas), following the same
-  [`AssetCache`](/Forge/docs/api/interfaces/AssetCache) contract as
-  [`ImageCache`](/Forge/docs/api/classes/ImageCache) (see
+  [`AssetCache`](/Forge/docs/api/interfaces/AssetCache) contract as the
+  rest of the engine's asset loading (see
   [Asset Loading](../asset-loading/index.md)).
-
-Guides in this section:
-
-- [Generating a Font Atlas](./generating-a-font-atlas.md): running
-  `forge-generate-font-atlas` against your own font.
-- [Loading a Font Atlas](./loading-a-font-atlas.md): using `FontAtlasCache`
-  to load a generated atlas, and what the resulting metrics look like.
 
 ## Quick start
 
@@ -54,5 +39,3 @@ const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font');
 
 console.log(fontAtlas.data.glyphs.get('A'.codePointAt(0)!));
 ```
-
-See the two guides above for the details behind each step.

--- a/documentation-site/docs/docs/text/index.md
+++ b/documentation-site/docs/docs/text/index.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 11
+---
+
+# Text
+
+The `text` module turns a `.ttf`/`.otf` font into a **multi-channel signed
+distance field (MSDF) atlas**: a small texture plus a metrics file that
+describes every glyph's shape and spacing. An MSDF atlas stays crisp at any
+render size (12px or 400px, zoomed in or out) without regenerating anything,
+because the texture stores each glyph's distance-to-edge rather than a fixed
+raster of pixels.
+
+:::info
+This module currently covers **generating and loading** a font atlas only.
+There is no `TextEcsComponent`, no text shaping, and no draw path yet, so
+you can't render text on screen with it. If you need on-screen text today,
+render it to a canvas texture yourself or overlay DOM on top of the game
+canvas. This page will be updated once rendering lands.
+:::
+
+Two pieces make up the pipeline:
+
+- An offline command, `forge-generate-font-atlas`, that reads a font file
+  and writes out an atlas image plus a
+  [`FontAtlasData`](/Forge/docs/api/interfaces/FontAtlasData)-shaped JSON
+  file, sized to your game's actual `charset`.
+- [`FontAtlasCache`](/Forge/docs/api/classes/FontAtlasCache), which loads
+  that JSON/image pair at runtime into a
+  [`FontAtlas`](/Forge/docs/api/interfaces/FontAtlas), following the same
+  [`AssetCache`](/Forge/docs/api/interfaces/AssetCache) contract as
+  [`ImageCache`](/Forge/docs/api/classes/ImageCache) (see
+  [Asset Loading](../asset-loading/index.md)).
+
+Guides in this section:
+
+- [Generating a Font Atlas](./generating-a-font-atlas.md): running
+  `forge-generate-font-atlas` against your own font.
+- [Loading a Font Atlas](./loading-a-font-atlas.md): using `FontAtlasCache`
+  to load a generated atlas, and what the resulting metrics look like.
+
+## Quick start
+
+```bash
+npm install --save-dev msdf-bmfont-xml
+npx forge-generate-font-atlas --font my-font.ttf --charset ascii --out assets/fonts/my-font
+```
+
+```ts
+import { FontAtlasCache } from '@forge-game-engine/forge/text';
+
+const fontAtlasCache = new FontAtlasCache();
+const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+
+console.log(fontAtlas.data.glyphs.get('A'.codePointAt(0)!));
+```
+
+See the two guides above for the details behind each step.

--- a/documentation-site/docs/docs/text/loading-a-font-atlas.md
+++ b/documentation-site/docs/docs/text/loading-a-font-atlas.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 2
+---
+
+# Loading a Font Atlas
+
+[`FontAtlasCache`](/Forge/docs/api/classes/FontAtlasCache) loads a
+generated atlas's JSON metrics and PNG texture into a
+[`FontAtlas`](/Forge/docs/api/interfaces/FontAtlas), the same
+`get` / `load` / `getOrLoad` shape as
+[`ImageCache`](/Forge/docs/api/classes/ImageCache) (see
+[Asset Loading](../asset-loading/index.md) for the shared
+[`AssetCache`](/Forge/docs/api/interfaces/AssetCache) contract).
+
+```ts
+import { FontAtlasCache } from '@forge-game-engine/forge/text';
+
+const fontAtlasCache = new FontAtlasCache();
+const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+```
+
+## Cache keys point at a JSON/image pair
+
+The key you pass is a path with no extension. `getOrLoad('assets/fonts/my-font')`
+fetches `assets/fonts/my-font.json`, then loads whatever image that JSON's
+`atlasImage` field names, resolved relative to the JSON file itself (so the
+`.png` doesn't have to share the exact base name as the key, though
+`forge-generate-font-atlas` always names them to match). As with
+`ImageCache`, the key is an exact string: `'assets/fonts/my-font'` and
+`'./assets/fonts/my-font'` are cached separately even though they'd resolve
+to the same files.
+
+:::caution
+Like `ImageCache`, `getOrLoad` does not deduplicate _in-flight_ loads.
+Calling it for the same key from two places before the first call resolves
+starts two separate fetches. Preload the fonts you need up front (e.g. with
+`Promise.all`) rather than calling `getOrLoad` lazily wherever a font is
+first needed.
+:::
+
+## Malformed or incompatible atlas files fail loudly
+
+`load`/`getOrLoad` reject with a descriptive error if the JSON fails to
+fetch, isn't valid JSON, or doesn't match the current
+[`FontAtlasData`](/Forge/docs/api/interfaces/FontAtlasData) schema (wrong
+`formatVersion`, a field with the wrong type, an out-of-range value). This
+matters most if you ever load atlases a player or mod could supply rather
+than ones your own build generated; a broken atlas fails at the `getOrLoad`
+call instead of surfacing as a confusing `NaN` somewhere downstream.
+
+## Reading glyph metrics
+
+`fontAtlas.data.glyphs` is a `Map<number, GlyphMetrics>` keyed by Unicode
+code point:
+
+```ts
+const glyph = fontAtlas.data.glyphs.get('A'.codePointAt(0)!);
+```
+
+- `advance`, `planeBounds`, and the font-level `metrics` (`lineHeight`,
+  `ascender`, `descender`) are all in **em units**: multiply by your desired
+  render size to get world/screen units. `planeBounds` is **Y-up**, relative
+  to the glyph's baseline, matching the rest of Forge's Y-up conventions.
+- `atlasBounds` is the glyph's texture rect, normalized `0` to `1`, with
+  `top` closer to the top of the atlas image than `bottom`.
+- Both `planeBounds` and `atlasBounds` are `null` for glyphs with no visible
+  ink, like space, there's nothing to draw for them.
+- A code point outside the atlas's generated charset simply isn't in the
+  map; `glyphs.get(...)` returns `undefined` rather than throwing, so check
+  for that if you're looking up characters you can't guarantee were
+  included when the atlas was generated.
+
+## Kerning lookups
+
+`fontAtlas.data.kerning` is a `Map<string, number>` keyed by
+[`getKerningPairKey(leftCodePoint, rightCodePoint)`](/Forge/docs/api/functions/getKerningPairKey).
+A pair with no explicit entry kerns by `0`, so a lookup miss is the normal,
+expected case for most glyph pairs, not an error condition:
+
+```ts
+import { getKerningPairKey } from '@forge-game-engine/forge/text';
+
+const kern =
+  fontAtlas.data.kerning.get(
+    getKerningPairKey('A'.codePointAt(0)!, 'V'.codePointAt(0)!),
+  ) ?? 0;
+```
+
+## Worked example
+
+```ts
+import { FontAtlasCache } from '@forge-game-engine/forge/text';
+
+const fontAtlasCache = new FontAtlasCache();
+
+const [headingAtlas, bodyAtlas] = await Promise.all([
+  fontAtlasCache.getOrLoad('assets/fonts/heading'),
+  fontAtlasCache.getOrLoad('assets/fonts/body'),
+]);
+
+const capitalA = bodyAtlas.data.glyphs.get('A'.codePointAt(0)!);
+
+if (capitalA?.planeBounds) {
+  const renderSize = 32;
+  const glyphWidthInPixels =
+    (capitalA.planeBounds.right - capitalA.planeBounds.left) * renderSize;
+}
+```

--- a/documentation-site/docs/docs/text/loading-a-font-atlas.md
+++ b/documentation-site/docs/docs/text/loading-a-font-atlas.md
@@ -6,47 +6,21 @@ sidebar_position: 2
 
 [`FontAtlasCache`](/Forge/docs/api/classes/FontAtlasCache) loads a
 generated atlas's JSON metrics and PNG texture into a
-[`FontAtlas`](/Forge/docs/api/interfaces/FontAtlas), the same
-`get` / `load` / `getOrLoad` shape as
-[`ImageCache`](/Forge/docs/api/classes/ImageCache) (see
-[Asset Loading](../asset-loading/index.md) for the shared
-[`AssetCache`](/Forge/docs/api/interfaces/AssetCache) contract).
+[`FontAtlas`](/Forge/docs/api/interfaces/FontAtlas).
 
 ```ts
 import { FontAtlasCache } from '@forge-game-engine/forge/text';
 
 const fontAtlasCache = new FontAtlasCache();
-const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font.json');
 ```
 
-## Cache keys point at a JSON/image pair
+## Cache keys point at the JSON file
 
-The key you pass is a path with no extension. `getOrLoad('assets/fonts/my-font')`
-fetches `assets/fonts/my-font.json`, then loads whatever image that JSON's
-`atlasImage` field names, resolved relative to the JSON file itself (so the
-`.png` doesn't have to share the exact base name as the key, though
-`forge-generate-font-atlas` always names them to match). As with
-`ImageCache`, the key is an exact string: `'assets/fonts/my-font'` and
-`'./assets/fonts/my-font'` are cached separately even though they'd resolve
-to the same files.
-
-:::caution
-Like `ImageCache`, `getOrLoad` does not deduplicate _in-flight_ loads.
-Calling it for the same key from two places before the first call resolves
-starts two separate fetches. Preload the fonts you need up front (e.g. with
-`Promise.all`) rather than calling `getOrLoad` lazily wherever a font is
-first needed.
-:::
-
-## Malformed or incompatible atlas files fail loudly
-
-`load`/`getOrLoad` reject with a descriptive error if the JSON fails to
-fetch, isn't valid JSON, or doesn't match the current
-[`FontAtlasData`](/Forge/docs/api/interfaces/FontAtlasData) schema (wrong
-`formatVersion`, a field with the wrong type, an out-of-range value). This
-matters most if you ever load atlases a player or mod could supply rather
-than ones your own build generated; a broken atlas fails at the `getOrLoad`
-call instead of surfacing as a confusing `NaN` somewhere downstream.
+`getOrLoad('assets/fonts/my-font.json')` fetches that file, then loads
+whatever image its `atlasImage` field names, resolved relative to the JSON
+file itself (so the `.png` doesn't have to share the exact base name,
+though `forge-generate-font-atlas` always names them to match).
 
 ## Reading glyph metrics
 
@@ -94,8 +68,8 @@ import { FontAtlasCache } from '@forge-game-engine/forge/text';
 const fontAtlasCache = new FontAtlasCache();
 
 const [headingAtlas, bodyAtlas] = await Promise.all([
-  fontAtlasCache.getOrLoad('assets/fonts/heading'),
-  fontAtlasCache.getOrLoad('assets/fonts/body'),
+  fontAtlasCache.getOrLoad('assets/fonts/heading.json'),
+  fontAtlasCache.getOrLoad('assets/fonts/body.json'),
 ]);
 
 const capitalA = bodyAtlas.data.glyphs.get('A'.codePointAt(0)!);

--- a/documentation-site/package-lock.json
+++ b/documentation-site/package-lock.json
@@ -45,36 +45,47 @@
         "imurmurhash": "^0.1.4",
         "seedrandom": "^3.0.5"
       },
+      "bin": {
+        "forge-generate-font-atlas": "scripts/generate-font-atlas.mjs"
+      },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
         "@eslint/js": "^10.0.1",
-        "@playwright/test": "1.56.0",
+        "@playwright/test": "1.62.1",
         "@types/howler": "^2.2.13",
-        "@types/node": "^22.10.0",
+        "@types/node": "^26.1.2",
         "@types/seedrandom": "^3.0.8",
+        "@vitest/coverage-v8": "^4.1.10",
         "@vitest/ui": "^4.0.6",
         "cspell": "^10.0.1",
         "eslint": "^10.7.0",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-jest": "^29.15.4",
+        "eslint-plugin-jest": "^29.16.0",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-sonarjs": "^4.2.0",
         "eslint-plugin-sort-exports": "^0.9.1",
-        "globals": "^17.7.0",
+        "globals": "^17.8.0",
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
+        "msdf-bmfont-xml": "^2.8.0",
         "prettier": "^3.9.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.64.0",
+        "typescript-eslint": "^8.65.0",
         "vite": "^8.1.5",
         "vite-plugin-dts": "^5.0.3",
         "vitest": "^4.1.10"
       },
       "peerDependencies": {
-        "howler": "^2.2.4"
+        "howler": "^2.2.4",
+        "msdf-bmfont-xml": "^2.8.0"
+      },
+      "peerDependenciesMeta": {
+        "msdf-bmfont-xml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@11ty/gray-matter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "globals": "^17.8.0",
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
+        "msdf-bmfont-xml": "^2.8.0",
         "prettier": "^3.9.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
@@ -232,6 +233,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@braidai/lang": {
@@ -1567,6 +1579,446 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jimp/core": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/file-ops": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "await-to-js": "^3.0.0",
+        "exif-parser": "^0.1.12",
+        "file-type": "^21.3.3",
+        "mime": "3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/diff": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.1.tgz",
+      "integrity": "sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "pixelmatch": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/file-ops": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.1.tgz",
+      "integrity": "sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-bmp": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.1.tgz",
+      "integrity": "sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "bmp-ts": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-gif": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.1.tgz",
+      "integrity": "sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "gifwrap": "^0.10.1",
+        "omggif": "^1.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-jpeg": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.1.tgz",
+      "integrity": "sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "jpeg-js": "^0.4.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-png": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.1.tgz",
+      "integrity": "sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "pngjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-tiff": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.1.tgz",
+      "integrity": "sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "utif2": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.1.tgz",
+      "integrity": "sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blur": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.1.tgz",
+      "integrity": "sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/utils": "1.6.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-circle": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.1.tgz",
+      "integrity": "sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-color": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.1.tgz",
+      "integrity": "sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "tinycolor2": "^1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-contain": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.1.tgz",
+      "integrity": "sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-cover": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.1.tgz",
+      "integrity": "sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-crop": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.1.tgz",
+      "integrity": "sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-displace": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.1.tgz",
+      "integrity": "sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-dither": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.1.tgz",
+      "integrity": "sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.1.tgz",
+      "integrity": "sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-flip": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.1.tgz",
+      "integrity": "sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-hash": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.1.tgz",
+      "integrity": "sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/js-bmp": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/js-tiff": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "any-base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-mask": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.1.tgz",
+      "integrity": "sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-print": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.1.tgz",
+      "integrity": "sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "parse-bmfont-ascii": "^1.0.6",
+        "parse-bmfont-binary": "^1.0.6",
+        "parse-bmfont-xml": "^1.1.6",
+        "simple-xml-to-json": "^1.2.2",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.1.tgz",
+      "integrity": "sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-resize": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.1.tgz",
+      "integrity": "sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.1.tgz",
+      "integrity": "sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.1.tgz",
+      "integrity": "sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-hash": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/types": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.1.tgz",
+      "integrity": "sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1705,6 +2157,51 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@polka/url": {
@@ -2047,6 +2544,31 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2646,6 +3168,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -2691,10 +3223,24 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/arabic-persian-reshaper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arabic-persian-reshaper/-/arabic-persian-reshaper-1.0.1.tgz",
+      "integrity": "sha512-VYBjkhz6o4W1Xt4mD2LAReljJpLSw5CUZMqSBDIQRvFgUSlTKEYghapgBWvkeMWF4W+KF3Fm+/z8EywJU4PBeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2782,6 +3328,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
+    "node_modules/await-to-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2797,6 +3364,121 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bmp-ts": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
+      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/brace-expansion": {
@@ -2853,6 +3535,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chai": {
@@ -2928,6 +3623,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-highlight": {
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
@@ -2996,6 +3704,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cli-table3": {
@@ -3158,6 +3879,43 @@
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/conventional-changelog-angular": {
       "version": "9.2.1",
@@ -3565,6 +4323,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3590,6 +4358,22 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/emoji-regex": {
@@ -3678,6 +4462,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4034,6 +4831,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exif-parser": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==",
+      "dev": true
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4144,6 +4947,25 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4237,6 +5059,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gifwrap": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "omggif": "^1.0.10"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4277,6 +5110,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
       }
     },
     "node_modules/has-flag": {
@@ -4342,6 +5204,27 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4351,6 +5234,23 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/image-q": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "16.9.1"
+      }
+    },
+    "node_modules/image-q/node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -4449,6 +5349,101 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally/node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-invalid-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-1.0.2.tgz",
+      "integrity": "sha512-6KLcFrPCEP3AFXMfnWrIFkZpYNBVzZAoBJJDEZKtI3LXkaDjM3uFMJQjxiizUuZTZ9Oh9FNv/soXbx5TcpaDmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
+      "integrity": "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -4528,6 +5523,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/jimp": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
+      "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/diff": "1.6.1",
+        "@jimp/js-bmp": "1.6.1",
+        "@jimp/js-gif": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/js-tiff": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/plugin-blur": "1.6.1",
+        "@jimp/plugin-circle": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-contain": "1.6.1",
+        "@jimp/plugin-cover": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-displace": "1.6.1",
+        "@jimp/plugin-dither": "1.6.1",
+        "@jimp/plugin-fisheye": "1.6.1",
+        "@jimp/plugin-flip": "1.6.1",
+        "@jimp/plugin-hash": "1.6.1",
+        "@jimp/plugin-mask": "1.6.1",
+        "@jimp/plugin-print": "1.6.1",
+        "@jimp/plugin-quantize": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/plugin-rotate": "1.6.1",
+        "@jimp/plugin-threshold": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -4537,6 +5571,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4566,6 +5607,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js2xmlparser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-5.0.0.tgz",
+      "integrity": "sha512-ckXs0Fzd6icWurbeAXuqo+3Mhq2m8pOPygsQjTPh8K5UWgKaUgDSHrdDxAfexmT11xvBKOQ6sgYwPkYc5RW/bg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
       }
     },
     "node_modules/jsdom": {
@@ -4663,6 +5714,35 @@
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
+      "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5042,6 +6122,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/map-limit": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
+      "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "~1.3.0"
+      }
+    },
     "node_modules/marked": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
@@ -5090,12 +6180,32 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/maxrects-packer": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/maxrects-packer/-/maxrects-packer-2.7.3.tgz",
+      "integrity": "sha512-bG6qXujJ1QgttZVIH4WDanhoJtvbud/xP/XPyf6A69C9RdA61BM4TomFALCq2nrTa+tARRIBB4LuIFsnUQU2wA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -5111,6 +6221,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mlly": {
@@ -5162,6 +6282,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msdf-bmfont-xml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/msdf-bmfont-xml/-/msdf-bmfont-xml-2.8.0.tgz",
+      "integrity": "sha512-VK6US7QqNhY9K5sq6TKlpKNlbBch1M2P1vLirf8mZLHK3j7X86fM4sqEyVnwCBYwZ/xiTbJeUWMEv5Ji+jQQMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arabic-persian-reshaper": "^1.0.1",
+        "cli-progress": "^3.12.0",
+        "commander": "^14.0.0",
+        "handlebars": "^4.7.8",
+        "is-invalid-path": "^1.0.2",
+        "jimp": "^1.6.0",
+        "js2xmlparser": "^5.0.0",
+        "map-limit": "0.0.1",
+        "maxrects-packer": "^2.7.3",
+        "opentype.js": "^1.3.4",
+        "update-notifier": "^7.3.1"
+      },
+      "bin": {
+        "msdf-bmfont": "cli.js"
+      }
+    },
+    "node_modules/msdf-bmfont-xml/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -5197,6 +6350,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5236,6 +6396,40 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opentype.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string.prototype.codepointat": "^0.2.1",
+        "tiny-inflate": "^1.0.3"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -5287,6 +6481,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
+      "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ky": "^1.2.0",
+        "registry-auth-token": "^5.0.2",
+        "registry-url": "^6.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5298,6 +6518,31 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-bmfont-ascii": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-binary": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-xml": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.5.0"
       }
     },
     "node_modules/parse-json": {
@@ -5403,6 +6648,29 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
@@ -5460,6 +6728,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -5530,6 +6808,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5538,6 +6823,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
+      "integrity": "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/quansync": {
@@ -5556,6 +6857,29 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/refa": {
       "version": "0.12.1",
@@ -5582,6 +6906,35 @@
       },
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+      "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/require-directory": {
@@ -5646,6 +6999,16 @@
         "@rolldown/binding-wasm32-wasi": "1.1.5",
         "@rolldown/binding-win32-arm64-msvc": "1.1.5",
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/saxes": {
@@ -5725,6 +7088,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-xml-to-json": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+      "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.12.2"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -5766,6 +7139,16 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5805,6 +7188,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -5827,6 +7217,50 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -5904,10 +7338,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5967,6 +7415,25 @@
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/totalist": {
       "version": "3.0.1",
@@ -6082,6 +7549,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6126,6 +7606,33 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/undici": {
       "version": "7.29.0",
@@ -6224,6 +7731,44 @@
         }
       }
     },
+    "node_modules/update-notifier": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
+      "integrity": "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^8.0.1",
+        "chalk": "^5.3.0",
+        "configstore": "^7.0.0",
+        "is-in-ci": "^1.0.0",
+        "is-installed-globally": "^1.0.0",
+        "is-npm": "^6.0.0",
+        "latest-version": "^9.0.0",
+        "pupa": "^3.1.0",
+        "semver": "^7.6.3",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/update-notifier/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6232,6 +7777,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utif2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.11"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -6514,6 +8069,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6547,6 +8109,63 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6556,6 +8175,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -6574,6 +8200,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/xdg-basedir": {
       "version": "5.1.0",
@@ -6598,12 +8231,50 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml-parse-from-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -6721,6 +8392,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,12 @@
         "default": "./dist/rendering/index.js"
       }
     },
+    "./text": {
+      "import": {
+        "types": "./dist/text/index.d.ts",
+        "default": "./dist/text/index.js"
+      }
+    },
     "./timer": {
       "import": {
         "types": "./dist/timer/index.d.ts",
@@ -107,6 +113,7 @@
     "dev": "vite --config vite.config.demo.js",
     "dev:e2e": "vite --config vite.config.e2e.js --port 4300 --strictPort",
     "build": "tsc --project tsconfig.build.json && node scripts/copy-shaders.js",
+    "generate-font-atlas": "node scripts/generate-font-atlas.mjs",
     "test:ui": "vitest --reporter=html",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -149,6 +156,7 @@
     "globals": "^17.8.0",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
+    "msdf-bmfont-xml": "^2.8.0",
     "prettier": "^3.9.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -101,8 +101,12 @@
     }
   },
   "types": "./dist/index.d.ts",
+  "bin": {
+    "forge-generate-font-atlas": "scripts/generate-font-atlas.mjs"
+  },
   "files": [
     "dist",
+    "scripts/generate-font-atlas.mjs",
     "README.md"
   ],
   "repository": {
@@ -166,7 +170,13 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "howler": "^2.2.4"
+    "howler": "^2.2.4",
+    "msdf-bmfont-xml": "^2.8.0"
+  },
+  "peerDependenciesMeta": {
+    "msdf-bmfont-xml": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@types/imurmurhash": "^0.1.4",

--- a/scripts/generate-font-atlas.mjs
+++ b/scripts/generate-font-atlas.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 async function loadGenerateBMFont() {
   try {
@@ -11,10 +13,36 @@ async function loadGenerateBMFont() {
       throw error;
     }
 
+    const globalGenerateBMFont = await loadGlobalGenerateBMFont();
+
+    if (globalGenerateBMFont) {
+      return globalGenerateBMFont;
+    }
+
     throw new Error(
-      'msdf-bmfont-xml is required to generate a font atlas but is not installed. Run `npm install --save-dev msdf-bmfont-xml` (an optional peer dependency of @forge-game-engine/forge) and try again.',
+      'msdf-bmfont-xml is required to generate a font atlas but is not installed. Run `npm install --save-dev msdf-bmfont-xml` or `npm install -g msdf-bmfont-xml` and try again.',
       { cause: error },
     );
+  }
+}
+
+// A global install isn't a resolvable specifier for `import()` (ESM ignores
+// NODE_PATH), so a global msdf-bmfont-xml needs its absolute location looked
+// up and imported directly.
+async function loadGlobalGenerateBMFont() {
+  try {
+    const globalRoot = execFileSync('npm', ['root', '-g'], {
+      encoding: 'utf-8',
+    }).trim();
+    const packageDir = join(globalRoot, 'msdf-bmfont-xml');
+    const packageJson = JSON.parse(
+      readFileSync(join(packageDir, 'package.json'), 'utf-8'),
+    );
+    const entryPath = join(packageDir, packageJson.main ?? 'index.js');
+
+    return (await import(pathToFileURL(entryPath).href)).default;
+  } catch {
+    return null;
   }
 }
 

--- a/scripts/generate-font-atlas.mjs
+++ b/scripts/generate-font-atlas.mjs
@@ -2,7 +2,16 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import generateBMFont from 'msdf-bmfont-xml';
+
+async function loadGenerateBMFont() {
+  try {
+    return (await import('msdf-bmfont-xml')).default;
+  } catch {
+    throw new Error(
+      'msdf-bmfont-xml is required to generate a font atlas but is not installed. Run `npm install --save-dev msdf-bmfont-xml` (an optional peer dependency of @forge-game-engine/forge) and try again.',
+    );
+  }
+}
 
 // Printable ASCII, the same default charset most BMFont/MSDF tools use.
 const ASCII_CHARSET = Array.from({ length: 126 - 32 + 1 }, (_, i) =>
@@ -29,10 +38,16 @@ function readFlag(name, defaultValue) {
 
 function printHelp() {
   console.log(`
-Usage: node scripts/generate-font-atlas.mjs --font <path> --out <path> [options]
+Usage: npx forge-generate-font-atlas --font <path> --out <path> [options]
+   or: npm run generate-font-atlas -- --font <path> --out <path> [options]
+       (from within the Forge repo itself)
 
 Generates a multi-channel signed distance field (MSDF) font atlas from a
 .ttf/.otf font file: an atlas PNG plus a normalized FontAtlasData JSON file.
+
+Requires msdf-bmfont-xml, an optional peer dependency of
+@forge-game-engine/forge - install it with
+\`npm install --save-dev msdf-bmfont-xml\` first.
 
 Options:
   --font <path>            Path to the input .ttf/.otf font file. Required.
@@ -150,7 +165,7 @@ function normalizeBmfontJson(raw, atlasImageFilename) {
   };
 }
 
-function generateBMFontAsync(fontPath, options) {
+function generateBMFontAsync(generateBMFont, fontPath, options) {
   return new Promise((resolvePromise, rejectPromise) => {
     generateBMFont(fontPath, options, (error, textures, font) => {
       if (error) {
@@ -175,6 +190,8 @@ async function main() {
     throw new Error('--font and --out are required.');
   }
 
+  const generateBMFont = await loadGenerateBMFont();
+
   const charsetArg = readFlag('charset', 'ascii');
   const fontSize = Number(readFlag('size', '42'));
   const distanceRange = Number(readFlag('distance-range', '4'));
@@ -186,14 +203,18 @@ async function main() {
 
   mkdirSync(outDir, { recursive: true });
 
-  const { textures, font } = await generateBMFontAsync(resolve(fontPath), {
-    charset: resolveCharset(charsetArg),
-    outputType: 'json',
-    fontSize,
-    distanceRange,
-    fieldType: 'msdf',
-    textureSize: [textureWidth, textureHeight],
-  });
+  const { textures, font } = await generateBMFontAsync(
+    generateBMFont,
+    resolve(fontPath),
+    {
+      charset: resolveCharset(charsetArg),
+      outputType: 'json',
+      fontSize,
+      distanceRange,
+      fieldType: 'msdf',
+      textureSize: [textureWidth, textureHeight],
+    },
+  );
 
   if (textures.length !== 1) {
     throw new Error(

--- a/scripts/generate-font-atlas.mjs
+++ b/scripts/generate-font-atlas.mjs
@@ -6,9 +6,14 @@ import { dirname, resolve } from 'node:path';
 async function loadGenerateBMFont() {
   try {
     return (await import('msdf-bmfont-xml')).default;
-  } catch {
+  } catch (error) {
+    if (error?.code !== 'ERR_MODULE_NOT_FOUND') {
+      throw error;
+    }
+
     throw new Error(
       'msdf-bmfont-xml is required to generate a font atlas but is not installed. Run `npm install --save-dev msdf-bmfont-xml` (an optional peer dependency of @forge-game-engine/forge) and try again.',
+      { cause: error },
     );
   }
 }

--- a/scripts/generate-font-atlas.mjs
+++ b/scripts/generate-font-atlas.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import generateBMFont from 'msdf-bmfont-xml';
+
+// Printable ASCII, the same default charset most BMFont/MSDF tools use.
+const ASCII_CHARSET = Array.from({ length: 126 - 32 + 1 }, (_, i) =>
+  String.fromCharCode(32 + i),
+);
+
+const CHARSET_PRESETS = {
+  ascii: ASCII_CHARSET,
+};
+
+const CURRENT_FONT_ATLAS_FORMAT_VERSION = 1;
+
+const args = process.argv.slice(2);
+
+function readFlag(name, defaultValue) {
+  const index = args.indexOf(`--${name}`);
+
+  if (index === -1 || index === args.length - 1) {
+    return defaultValue;
+  }
+
+  return args[index + 1];
+}
+
+function printHelp() {
+  console.log(`
+Usage: node scripts/generate-font-atlas.mjs --font <path> --out <path> [options]
+
+Generates a multi-channel signed distance field (MSDF) font atlas from a
+.ttf/.otf font file: an atlas PNG plus a normalized FontAtlasData JSON file.
+
+Options:
+  --font <path>            Path to the input .ttf/.otf font file. Required.
+  --out <path>              Output path, without extension. Writes
+                             <out>.png and <out>.json. Required.
+  --charset <name|string|path>
+                             "ascii" (default) for printable ASCII, a literal
+                             string of characters, or a path to a text file
+                             containing the characters to include.
+  --size <n>                 Font size the distance field is authored at, in
+                              pixels. Defaults to 42.
+  --distance-range <n>       The distance field's encoded range, in pixels.
+                              Defaults to 4.
+  --texture-width <n>        Atlas texture width, in pixels. Defaults to 512.
+  --texture-height <n>       Atlas texture height, in pixels. Defaults to 512.
+  --help, -h                 Show this help information.
+`);
+}
+
+if (args.includes('--help') || args.includes('-h')) {
+  printHelp();
+  process.exit(0);
+}
+
+function resolveCharset(charsetArg) {
+  if (charsetArg in CHARSET_PRESETS) {
+    return CHARSET_PRESETS[charsetArg];
+  }
+
+  if (existsSync(charsetArg)) {
+    return readFileSync(charsetArg, 'utf-8');
+  }
+
+  return charsetArg;
+}
+
+/**
+ * Converts one BMFont `chars[]` entry (pixel-space, Y-down from the line's
+ * top) into a `GlyphMetrics`-shaped object (em units, Y-up, relative to the
+ * baseline).
+ */
+function normalizeGlyph(char, fontSize, base, atlasWidth, atlasHeight) {
+  const hasInk = char.width > 0 && char.height > 0;
+
+  const planeBounds = hasInk
+    ? {
+        left: char.xoffset / fontSize,
+        top: (base - char.yoffset) / fontSize,
+        right: (char.xoffset + char.width) / fontSize,
+        bottom: (base - char.yoffset - char.height) / fontSize,
+      }
+    : null;
+
+  const atlasBounds = hasInk
+    ? {
+        left: char.x / atlasWidth,
+        top: 1 - char.y / atlasHeight,
+        right: (char.x + char.width) / atlasWidth,
+        bottom: 1 - (char.y + char.height) / atlasHeight,
+      }
+    : null;
+
+  return {
+    codePoint: char.id,
+    advance: char.xadvance / fontSize,
+    planeBounds,
+    atlasBounds,
+  };
+}
+
+/**
+ * Normalizes msdf-bmfont-xml's raw BMFont-JSON output into Forge's own,
+ * versioned `FontAtlasFileData` schema (see `src/text/font-atlas`), so
+ * runtime consumers never depend on a third-party generator's own format.
+ */
+function normalizeBmfontJson(raw, atlasImageFilename) {
+  if (raw.distanceField?.fieldType !== 'msdf') {
+    throw new Error(
+      `Expected a "msdf" distance field, got "${raw.distanceField?.fieldType}". Forge's text renderer only supports MSDF atlases (see design/msdf-text-rendering.md, DL-05).`,
+    );
+  }
+
+  if (raw.pages.length !== 1) {
+    throw new Error(
+      `Expected exactly one atlas page, got ${raw.pages.length}. Multi-page atlases are not supported; reduce the charset or increase the texture size.`,
+    );
+  }
+
+  const fontSize = raw.info.size;
+  const { base, lineHeight, scaleW, scaleH } = raw.common;
+
+  const glyphs = raw.chars.map((char) =>
+    normalizeGlyph(char, fontSize, base, scaleW, scaleH),
+  );
+
+  const kerning = {};
+
+  for (const pair of raw.kernings) {
+    kerning[`${pair.first}:${pair.second}`] = pair.amount / fontSize;
+  }
+
+  return {
+    formatVersion: CURRENT_FONT_ATLAS_FORMAT_VERSION,
+    type: 'msdf',
+    atlasImage: atlasImageFilename,
+    atlasSize: { width: scaleW, height: scaleH },
+    distanceRange: raw.distanceField.distanceRange,
+    metrics: {
+      lineHeight: lineHeight / fontSize,
+      ascender: base / fontSize,
+      descender: (base - lineHeight) / fontSize,
+    },
+    glyphs,
+    kerning,
+  };
+}
+
+function generateBMFontAsync(fontPath, options) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    generateBMFont(fontPath, options, (error, textures, font) => {
+      if (error) {
+        rejectPromise(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+
+        return;
+      }
+
+      resolvePromise({ textures, font });
+    });
+  });
+}
+
+async function main() {
+  const fontPath = readFlag('font');
+  const outPath = readFlag('out');
+
+  if (!fontPath || !outPath) {
+    printHelp();
+    throw new Error('--font and --out are required.');
+  }
+
+  const charsetArg = readFlag('charset', 'ascii');
+  const fontSize = Number(readFlag('size', '42'));
+  const distanceRange = Number(readFlag('distance-range', '4'));
+  const textureWidth = Number(readFlag('texture-width', '512'));
+  const textureHeight = Number(readFlag('texture-height', '512'));
+
+  const resolvedOutPath = resolve(outPath);
+  const outDir = dirname(resolvedOutPath);
+
+  mkdirSync(outDir, { recursive: true });
+
+  const { textures, font } = await generateBMFontAsync(resolve(fontPath), {
+    charset: resolveCharset(charsetArg),
+    outputType: 'json',
+    fontSize,
+    distanceRange,
+    fieldType: 'msdf',
+    textureSize: [textureWidth, textureHeight],
+  });
+
+  if (textures.length !== 1) {
+    throw new Error(
+      `Expected exactly one atlas texture, got ${textures.length}. Multi-page atlases are not supported; reduce the charset or increase the texture size.`,
+    );
+  }
+
+  const raw = JSON.parse(font.data);
+  const atlasImageFilename = `${resolveOutBasename(resolvedOutPath)}.png`;
+  const fileData = normalizeBmfontJson(raw, atlasImageFilename);
+
+  writeFileSync(`${resolvedOutPath}.png`, textures[0].texture);
+  writeFileSync(`${resolvedOutPath}.json`, JSON.stringify(fileData, null, 2));
+
+  console.log(
+    `> Generated font atlas: ${resolvedOutPath}.png + ${resolvedOutPath}.json (${fileData.glyphs.length} glyphs, ${Object.keys(fileData.kerning).length} kerning pairs)`,
+  );
+}
+
+function resolveOutBasename(resolvedOutPath) {
+  const separatorIndex = resolvedOutPath.lastIndexOf('/');
+
+  return separatorIndex === -1
+    ? resolvedOutPath
+    : resolvedOutPath.slice(separatorIndex + 1);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error('❌ Error generating font atlas:', error);
+  process.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from './input/index.js';
 export * from './lifecycle/index.js';
 export * from './math/index.js';
 export * from './rendering/index.js';
+export * from './text/index.js';
 export * from './timer/index.js';
 export * from './utilities/index.js';
 export * from './finite-state-machine/index.js';

--- a/src/text/font-atlas/font-atlas-cache.test.ts
+++ b/src/text/font-atlas/font-atlas-cache.test.ts
@@ -78,6 +78,20 @@ describe('FontAtlasCache', () => {
     );
   });
 
+  it('should resolve the atlas image relative to a root-level key', async () => {
+    mockFetchJsonResponse(buildValidJson());
+
+    const imageCache = new ImageCache();
+    const getOrLoadSpy = vi
+      .spyOn(imageCache, 'getOrLoad')
+      .mockResolvedValue(new Image());
+
+    const fontAtlasCache = new FontAtlasCache(imageCache);
+    await fontAtlasCache.getOrLoad('my-font');
+
+    expect(getOrLoadSpy).toHaveBeenCalledWith('my-font.png');
+  });
+
   it('should not re-fetch a font atlas that is already cached', async () => {
     mockFetchJsonResponse(buildValidJson());
 

--- a/src/text/font-atlas/font-atlas-cache.test.ts
+++ b/src/text/font-atlas/font-atlas-cache.test.ts
@@ -38,8 +38,8 @@ describe('FontAtlasCache', () => {
   it('should throw when getting a font atlas that has not been loaded', () => {
     const fontAtlasCache = new FontAtlasCache();
 
-    expect(() => fontAtlasCache.get('assets/fonts/my-font')).toThrow(
-      'Font atlas with key "assets/fonts/my-font" not found in store.',
+    expect(() => fontAtlasCache.get('assets/fonts/my-font.json')).toThrow(
+      'Font atlas with key "assets/fonts/my-font.json" not found in store.',
     );
   });
 
@@ -53,13 +53,15 @@ describe('FontAtlasCache', () => {
       .mockResolvedValue(mockImage);
 
     const fontAtlasCache = new FontAtlasCache(imageCache);
-    const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+    const fontAtlas = await fontAtlasCache.getOrLoad(
+      'assets/fonts/my-font.json',
+    );
 
     expect(fetch).toHaveBeenCalledWith('assets/fonts/my-font.json');
     expect(getOrLoadSpy).toHaveBeenCalledWith('assets/fonts/my-font.png');
     expect(fontAtlas.image).toBe(mockImage);
     expect(fontAtlas.data.glyphs.get(65)?.advance).toBeCloseTo(0.6);
-    expect(fontAtlasCache.get('assets/fonts/my-font')).toBe(fontAtlas);
+    expect(fontAtlasCache.get('assets/fonts/my-font.json')).toBe(fontAtlas);
   });
 
   it('should resolve the atlas image relative to a nested key', async () => {
@@ -71,7 +73,7 @@ describe('FontAtlasCache', () => {
       .mockResolvedValue(new Image());
 
     const fontAtlasCache = new FontAtlasCache(imageCache);
-    await fontAtlasCache.getOrLoad('assets/fonts/heading/my-font');
+    await fontAtlasCache.getOrLoad('assets/fonts/heading/my-font.json');
 
     expect(getOrLoadSpy).toHaveBeenCalledWith(
       'assets/fonts/heading/my-font.png',
@@ -87,7 +89,7 @@ describe('FontAtlasCache', () => {
       .mockResolvedValue(new Image());
 
     const fontAtlasCache = new FontAtlasCache(imageCache);
-    await fontAtlasCache.getOrLoad('my-font');
+    await fontAtlasCache.getOrLoad('my-font.json');
 
     expect(getOrLoadSpy).toHaveBeenCalledWith('my-font.png');
   });
@@ -99,8 +101,8 @@ describe('FontAtlasCache', () => {
     vi.spyOn(imageCache, 'getOrLoad').mockResolvedValue(new Image());
 
     const fontAtlasCache = new FontAtlasCache(imageCache);
-    await fontAtlasCache.getOrLoad('assets/fonts/my-font');
-    await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+    await fontAtlasCache.getOrLoad('assets/fonts/my-font.json');
+    await fontAtlasCache.getOrLoad('assets/fonts/my-font.json');
 
     expect(fetch).toHaveBeenCalledTimes(1);
   });
@@ -111,7 +113,7 @@ describe('FontAtlasCache', () => {
     const fontAtlasCache = new FontAtlasCache();
 
     await expect(
-      fontAtlasCache.getOrLoad('assets/fonts/missing-font'),
+      fontAtlasCache.getOrLoad('assets/fonts/missing-font.json'),
     ).rejects.toThrow(
       'Failed to load font atlas JSON at "assets/fonts/missing-font.json": 404 Not Found',
     );
@@ -123,7 +125,7 @@ describe('FontAtlasCache', () => {
     const fontAtlasCache = new FontAtlasCache();
 
     await expect(
-      fontAtlasCache.getOrLoad('assets/fonts/broken-font'),
+      fontAtlasCache.getOrLoad('assets/fonts/broken-font.json'),
     ).rejects.toThrow(/unsupported formatVersion "999"/);
   });
 });

--- a/src/text/font-atlas/font-atlas-cache.test.ts
+++ b/src/text/font-atlas/font-atlas-cache.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ImageCache } from '../../asset-loading/index.js';
+import { CURRENT_FONT_ATLAS_FORMAT_VERSION } from './font-atlas-data.js';
+import type { FontAtlasFileData } from './font-atlas-file-data.js';
+import { FontAtlasCache } from './font-atlas-cache.js';
+
+const buildValidJson = (): FontAtlasFileData => ({
+  formatVersion: CURRENT_FONT_ATLAS_FORMAT_VERSION,
+  type: 'msdf',
+  atlasImage: 'my-font.png',
+  atlasSize: { width: 512, height: 512 },
+  distanceRange: 4,
+  metrics: { lineHeight: 1.2, ascender: 0.9, descender: -0.2 },
+  glyphs: [
+    {
+      codePoint: 65,
+      advance: 0.6,
+      planeBounds: { left: 0.05, bottom: 0, right: 0.55, top: 0.7 },
+      atlasBounds: { left: 0.1, bottom: 0.2, right: 0.2, top: 0.3 },
+    },
+  ],
+  kerning: {},
+});
+
+function mockFetchJsonResponse(json: unknown, ok = true): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 200 : 404,
+      statusText: ok ? 'OK' : 'Not Found',
+      json: () => Promise.resolve(json),
+    }),
+  );
+}
+
+describe('FontAtlasCache', () => {
+  it('should throw when getting a font atlas that has not been loaded', () => {
+    const fontAtlasCache = new FontAtlasCache();
+
+    expect(() => fontAtlasCache.get('assets/fonts/my-font')).toThrow(
+      'Font atlas with key "assets/fonts/my-font" not found in store.',
+    );
+  });
+
+  it('should load and cache a valid font atlas', async () => {
+    mockFetchJsonResponse(buildValidJson());
+
+    const mockImage = new Image();
+    const imageCache = new ImageCache();
+    const getOrLoadSpy = vi
+      .spyOn(imageCache, 'getOrLoad')
+      .mockResolvedValue(mockImage);
+
+    const fontAtlasCache = new FontAtlasCache(imageCache);
+    const fontAtlas = await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+
+    expect(fetch).toHaveBeenCalledWith('assets/fonts/my-font.json');
+    expect(getOrLoadSpy).toHaveBeenCalledWith('assets/fonts/my-font.png');
+    expect(fontAtlas.image).toBe(mockImage);
+    expect(fontAtlas.data.glyphs.get(65)?.advance).toBeCloseTo(0.6);
+    expect(fontAtlasCache.get('assets/fonts/my-font')).toBe(fontAtlas);
+  });
+
+  it('should resolve the atlas image relative to a nested key', async () => {
+    mockFetchJsonResponse(buildValidJson());
+
+    const imageCache = new ImageCache();
+    const getOrLoadSpy = vi
+      .spyOn(imageCache, 'getOrLoad')
+      .mockResolvedValue(new Image());
+
+    const fontAtlasCache = new FontAtlasCache(imageCache);
+    await fontAtlasCache.getOrLoad('assets/fonts/heading/my-font');
+
+    expect(getOrLoadSpy).toHaveBeenCalledWith(
+      'assets/fonts/heading/my-font.png',
+    );
+  });
+
+  it('should not re-fetch a font atlas that is already cached', async () => {
+    mockFetchJsonResponse(buildValidJson());
+
+    const imageCache = new ImageCache();
+    vi.spyOn(imageCache, 'getOrLoad').mockResolvedValue(new Image());
+
+    const fontAtlasCache = new FontAtlasCache(imageCache);
+    await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+    await fontAtlasCache.getOrLoad('assets/fonts/my-font');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw a descriptive error when the JSON fetch fails', async () => {
+    mockFetchJsonResponse({}, false);
+
+    const fontAtlasCache = new FontAtlasCache();
+
+    await expect(
+      fontAtlasCache.getOrLoad('assets/fonts/missing-font'),
+    ).rejects.toThrow(
+      'Failed to load font atlas JSON at "assets/fonts/missing-font.json": 404 Not Found',
+    );
+  });
+
+  it('should throw a descriptive error when the JSON is malformed', async () => {
+    mockFetchJsonResponse({ formatVersion: 999 });
+
+    const fontAtlasCache = new FontAtlasCache();
+
+    await expect(
+      fontAtlasCache.getOrLoad('assets/fonts/broken-font'),
+    ).rejects.toThrow(/unsupported formatVersion "999"/);
+  });
+});

--- a/src/text/font-atlas/font-atlas-cache.ts
+++ b/src/text/font-atlas/font-atlas-cache.ts
@@ -1,0 +1,90 @@
+import { type AssetCache, ImageCache } from '../../asset-loading/index.js';
+import type { FontAtlas } from './font-atlas.js';
+import { toFontAtlasData } from './font-atlas-file-data.js';
+import { validateFontAtlasFileData } from './validate-font-atlas-data.js';
+
+/**
+ * Loads and caches `FontAtlas`es: a metrics JSON file plus its atlas image,
+ * keyed by a shared base path (e.g. `getOrLoad('assets/fonts/my-font')`
+ * loads `assets/fonts/my-font.json`, which in turn points at its own atlas
+ * image, resolved relative to that JSON file).
+ */
+export class FontAtlasCache implements AssetCache<FontAtlas> {
+  public assets = new Map<string, FontAtlas>();
+
+  private readonly _imageCache: ImageCache;
+
+  constructor(imageCache: ImageCache = new ImageCache()) {
+    this._imageCache = imageCache;
+  }
+
+  /**
+   * Retrieves a font atlas from the cache.
+   * @param key - The key of the font atlas to retrieve.
+   * @returns The cached font atlas.
+   * @throws Will throw an error if the font atlas is not found in the cache.
+   */
+  public get(key: string): FontAtlas {
+    const fontAtlas = this.assets.get(key);
+
+    if (!fontAtlas) {
+      throw new Error(`Font atlas with key "${key}" not found in store.`);
+    }
+
+    return fontAtlas;
+  }
+
+  /**
+   * Loads a font atlas's JSON metrics and image from the specified key and
+   * caches it.
+   * @param key - The key of the font atlas to load, without a file extension.
+   * @returns A promise that resolves when the font atlas is loaded and cached.
+   * @throws Will throw an error if the JSON fails to fetch, is malformed, or
+   * is an unsupported/incompatible atlas format.
+   */
+  public async load(key: string): Promise<void> {
+    const jsonPath = `${key}.json`;
+    const response = await fetch(jsonPath);
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load font atlas JSON at "${jsonPath}": ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const rawJson: unknown = await response.json();
+    const fileData = validateFontAtlasFileData(rawJson, jsonPath);
+    const data = toFontAtlasData(fileData);
+    const imagePath = resolveRelativeToKey(key, data.atlasImage);
+    const image = await this._imageCache.getOrLoad(imagePath);
+
+    this.assets.set(key, { data, image });
+  }
+
+  /**
+   * Retrieves a font atlas from the cache if it exists, otherwise loads and
+   * caches it.
+   * @param key - The key of the font atlas to retrieve or load.
+   * @returns A promise that resolves to the font atlas.
+   */
+  public async getOrLoad(key: string): Promise<FontAtlas> {
+    if (!this.assets.has(key)) {
+      await this.load(key);
+    }
+
+    return this.get(key);
+  }
+}
+
+/**
+ * Resolves `relativePath` against the directory `key` sits in, the same way
+ * `FontAtlasData.atlasImage` is documented as being relative to its own
+ * JSON file.
+ */
+function resolveRelativeToKey(key: string, relativePath: string): string {
+  const lastSlashIndex = key.lastIndexOf('/');
+  const directory =
+    lastSlashIndex === -1 ? '' : key.slice(0, lastSlashIndex + 1);
+
+  return `${directory}${relativePath}`;
+}

--- a/src/text/font-atlas/font-atlas-cache.ts
+++ b/src/text/font-atlas/font-atlas-cache.ts
@@ -5,9 +5,9 @@ import { validateFontAtlasFileData } from './validate-font-atlas-data.js';
 
 /**
  * Loads and caches `FontAtlas`es: a metrics JSON file plus its atlas image,
- * keyed by a shared base path (e.g. `getOrLoad('assets/fonts/my-font')`
- * loads `assets/fonts/my-font.json`, which in turn points at its own atlas
- * image, resolved relative to that JSON file).
+ * keyed by the JSON file's path (e.g. `getOrLoad('assets/fonts/my-font.json')`
+ * loads that file, which in turn points at its own atlas image, resolved
+ * relative to the JSON file).
  */
 export class FontAtlasCache implements AssetCache<FontAtlas> {
   public assets = new Map<string, FontAtlas>();
@@ -20,7 +20,7 @@ export class FontAtlasCache implements AssetCache<FontAtlas> {
 
   /**
    * Retrieves a font atlas from the cache.
-   * @param key - The key of the font atlas to retrieve.
+   * @param key - The path of the font atlas's JSON file.
    * @returns The cached font atlas.
    * @throws Will throw an error if the font atlas is not found in the cache.
    */
@@ -37,23 +37,22 @@ export class FontAtlasCache implements AssetCache<FontAtlas> {
   /**
    * Loads a font atlas's JSON metrics and image from the specified key and
    * caches it.
-   * @param key - The key of the font atlas to load, without a file extension.
+   * @param key - The path of the font atlas's JSON file.
    * @returns A promise that resolves when the font atlas is loaded and cached.
    * @throws Will throw an error if the JSON fails to fetch, is malformed, or
    * is an unsupported/incompatible atlas format.
    */
   public async load(key: string): Promise<void> {
-    const jsonPath = `${key}.json`;
-    const response = await fetch(jsonPath);
+    const response = await fetch(key);
 
     if (!response.ok) {
       throw new Error(
-        `Failed to load font atlas JSON at "${jsonPath}": ${response.status} ${response.statusText}`,
+        `Failed to load font atlas JSON at "${key}": ${response.status} ${response.statusText}`,
       );
     }
 
     const rawJson: unknown = await response.json();
-    const fileData = validateFontAtlasFileData(rawJson, jsonPath);
+    const fileData = validateFontAtlasFileData(rawJson, key);
     const data = toFontAtlasData(fileData);
     const imagePath = resolveRelativeToKey(key, data.atlasImage);
     const image = await this._imageCache.getOrLoad(imagePath);

--- a/src/text/font-atlas/font-atlas-data.test.ts
+++ b/src/text/font-atlas/font-atlas-data.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { getKerningPairKey } from './font-atlas-data.js';
+
+describe('getKerningPairKey', () => {
+  it('should build a key from a left and right code point', () => {
+    expect(getKerningPairKey(65, 86)).toBe('65:86');
+  });
+
+  it('should build distinct keys for reversed pairs', () => {
+    expect(getKerningPairKey(65, 86)).not.toBe(getKerningPairKey(86, 65));
+  });
+});

--- a/src/text/font-atlas/font-atlas-data.ts
+++ b/src/text/font-atlas/font-atlas-data.ts
@@ -1,0 +1,121 @@
+/**
+ * A rectangle in a glyph's own coordinate space (see `GlyphMetrics.planeBounds`
+ * and `GlyphMetrics.atlasBounds` for the two spaces this is used in).
+ */
+export interface Bounds {
+  /** The rectangle's left edge. */
+  left: number;
+
+  /** The rectangle's bottom edge (smaller than `top`). */
+  bottom: number;
+
+  /** The rectangle's right edge. */
+  right: number;
+
+  /** The rectangle's top edge (larger than `bottom`). */
+  top: number;
+}
+
+/**
+ * The per-glyph metrics and geometry needed to shape and render one
+ * character from a `FontAtlas`.
+ */
+export interface GlyphMetrics {
+  /** The Unicode code point this glyph represents. */
+  codePoint: number;
+
+  /** Horizontal advance to the next glyph's origin, in em units. */
+  advance: number;
+
+  /**
+   * This glyph's quad, in em units relative to the text baseline origin,
+   * Y-up. `null` for glyphs with no visible ink (e.g. space).
+   */
+  planeBounds: Bounds | null;
+
+  /**
+   * This glyph's texture rect in the atlas, normalized 0 to 1 with `top`
+   * closer to the top of the atlas image than `bottom`. `null` for glyphs
+   * with no visible ink (e.g. space).
+   */
+  atlasBounds: Bounds | null;
+}
+
+/** Font metrics shared by every glyph in a `FontAtlas`, in em units. */
+export interface FontAtlasMetrics {
+  /** The default distance between successive lines' baselines. */
+  lineHeight: number;
+
+  /** The distance from the baseline to the top of the font's tallest glyphs. */
+  ascender: number;
+
+  /** The distance from the baseline to the bottom of the font's lowest-descending glyphs (negative). */
+  descender: number;
+}
+
+/** The pixel dimensions of an atlas texture. */
+export interface AtlasSize {
+  /** The atlas texture's width, in pixels. */
+  width: number;
+
+  /** The atlas texture's height, in pixels. */
+  height: number;
+}
+
+/**
+ * The current version of the `FontAtlasData`/`FontAtlasFileData` schema.
+ * Bumped on any breaking change to that shape.
+ */
+export const CURRENT_FONT_ATLAS_FORMAT_VERSION = 1 as const;
+
+/**
+ * The runtime, Forge-owned representation of a generated MSDF font atlas's
+ * metrics, decoupled from whichever offline tool generated it. Produced by
+ * `toFontAtlasData` from the on-disk `FontAtlasFileData` a `FontAtlasCache`
+ * loads.
+ */
+export interface FontAtlasData {
+  /** Schema version this data was produced from. */
+  formatVersion: typeof CURRENT_FONT_ATLAS_FORMAT_VERSION;
+
+  /** `'msdf'` for v1; reserved for `'mtsdf'` later. */
+  type: 'msdf';
+
+  /** Atlas texture path, relative to this atlas's JSON file. */
+  atlasImage: string;
+
+  /** Atlas texture pixel dimensions. */
+  atlasSize: AtlasSize;
+
+  /**
+   * The distance field's encoded range, in pixels, at the atlas's authored
+   * size. Required to compute the shader's `screenPxRange` at render time.
+   */
+  distanceRange: number;
+
+  /** Font metrics shared by every glyph. */
+  metrics: FontAtlasMetrics;
+
+  /** Keyed by Unicode code point. */
+  glyphs: Map<number, GlyphMetrics>;
+
+  /**
+   * Keyed by `getKerningPairKey(leftCodePoint, rightCodePoint)`. Absent
+   * pairs kern by `0`.
+   */
+  kerning: Map<string, number>;
+}
+
+/**
+ * Builds the lookup key `FontAtlasData.kerning` is keyed by for a pair of
+ * adjacent glyphs.
+ * @param leftCodePoint - The code point of the left glyph in the pair.
+ * @param rightCodePoint - The code point of the right glyph in the pair.
+ * @returns The kerning map key for this pair.
+ */
+export function getKerningPairKey(
+  leftCodePoint: number,
+  rightCodePoint: number,
+): string {
+  return `${leftCodePoint}:${rightCodePoint}`;
+}

--- a/src/text/font-atlas/font-atlas-file-data.test.ts
+++ b/src/text/font-atlas/font-atlas-file-data.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CURRENT_FONT_ATLAS_FORMAT_VERSION,
+  getKerningPairKey,
+} from './font-atlas-data.js';
+import {
+  type FontAtlasFileData,
+  toFontAtlasData,
+} from './font-atlas-file-data.js';
+
+const buildFileData = (): FontAtlasFileData => ({
+  formatVersion: CURRENT_FONT_ATLAS_FORMAT_VERSION,
+  type: 'msdf',
+  atlasImage: 'my-font.png',
+  atlasSize: { width: 512, height: 512 },
+  distanceRange: 4,
+  metrics: { lineHeight: 1.2, ascender: 0.9, descender: -0.2 },
+  glyphs: [
+    {
+      codePoint: 65,
+      advance: 0.6,
+      planeBounds: { left: 0.05, bottom: 0, right: 0.55, top: 0.7 },
+      atlasBounds: { left: 0.1, bottom: 0.2, right: 0.2, top: 0.3 },
+    },
+    {
+      codePoint: 32,
+      advance: 0.3,
+      planeBounds: null,
+      atlasBounds: null,
+    },
+  ],
+  kerning: {
+    [getKerningPairKey(65, 86)]: -0.05,
+  },
+});
+
+describe('toFontAtlasData', () => {
+  it('should carry scalar fields over unchanged', () => {
+    const result = toFontAtlasData(buildFileData());
+
+    expect(result.formatVersion).toBe(CURRENT_FONT_ATLAS_FORMAT_VERSION);
+    expect(result.type).toBe('msdf');
+    expect(result.atlasImage).toBe('my-font.png');
+    expect(result.atlasSize).toEqual({ width: 512, height: 512 });
+    expect(result.distanceRange).toBe(4);
+    expect(result.metrics).toEqual({
+      lineHeight: 1.2,
+      ascender: 0.9,
+      descender: -0.2,
+    });
+  });
+
+  it('should key glyphs by their code point', () => {
+    const result = toFontAtlasData(buildFileData());
+
+    expect(result.glyphs.size).toBe(2);
+    expect(result.glyphs.get(65)).toEqual({
+      codePoint: 65,
+      advance: 0.6,
+      planeBounds: { left: 0.05, bottom: 0, right: 0.55, top: 0.7 },
+      atlasBounds: { left: 0.1, bottom: 0.2, right: 0.2, top: 0.3 },
+    });
+    expect(result.glyphs.get(32)?.planeBounds).toBeNull();
+  });
+
+  it('should convert kerning pairs into a Map', () => {
+    const result = toFontAtlasData(buildFileData());
+
+    expect(result.kerning.get(getKerningPairKey(65, 86))).toBeCloseTo(-0.05);
+    expect(result.kerning.get(getKerningPairKey(86, 65))).toBeUndefined();
+  });
+});

--- a/src/text/font-atlas/font-atlas-file-data.ts
+++ b/src/text/font-atlas/font-atlas-file-data.ts
@@ -1,0 +1,58 @@
+import {
+  type AtlasSize,
+  CURRENT_FONT_ATLAS_FORMAT_VERSION,
+  type FontAtlasData,
+  type FontAtlasMetrics,
+  type GlyphMetrics,
+} from './font-atlas-data.js';
+
+/**
+ * The on-disk, JSON-serializable shape of a committed font atlas asset
+ * (`<name>.json`, sitting alongside `<name>.png`). This is the same data as
+ * `FontAtlasData`, except `glyphs`/`kerning` use JSON-safe arrays/records
+ * instead of `Map`s. `toFontAtlasData` converts one into the other.
+ */
+export interface FontAtlasFileData {
+  /** Schema version this file was written as. */
+  formatVersion: typeof CURRENT_FONT_ATLAS_FORMAT_VERSION;
+
+  /** `'msdf'` for v1; reserved for `'mtsdf'` later. */
+  type: 'msdf';
+
+  /** Atlas texture path, relative to this JSON file. */
+  atlasImage: string;
+
+  /** Atlas texture pixel dimensions. */
+  atlasSize: AtlasSize;
+
+  /** The distance field's encoded range, in pixels, at the atlas's authored size. */
+  distanceRange: number;
+
+  /** Font metrics shared by every glyph. */
+  metrics: FontAtlasMetrics;
+
+  /** One entry per glyph in the atlas. */
+  glyphs: GlyphMetrics[];
+
+  /** Keyed by `getKerningPairKey(leftCodePoint, rightCodePoint)`. */
+  kerning: Record<string, number>;
+}
+
+/**
+ * Converts the on-disk `FontAtlasFileData` shape into the runtime,
+ * `Map`-based `FontAtlasData` shape.
+ * @param fileData - The parsed and validated on-disk atlas data.
+ * @returns The runtime font atlas data.
+ */
+export function toFontAtlasData(fileData: FontAtlasFileData): FontAtlasData {
+  return {
+    formatVersion: fileData.formatVersion,
+    type: fileData.type,
+    atlasImage: fileData.atlasImage,
+    atlasSize: fileData.atlasSize,
+    distanceRange: fileData.distanceRange,
+    metrics: fileData.metrics,
+    glyphs: new Map(fileData.glyphs.map((glyph) => [glyph.codePoint, glyph])),
+    kerning: new Map(Object.entries(fileData.kerning)),
+  };
+}

--- a/src/text/font-atlas/font-atlas.ts
+++ b/src/text/font-atlas/font-atlas.ts
@@ -1,0 +1,14 @@
+import type { FontAtlasData } from './font-atlas-data.js';
+
+/**
+ * A fully loaded font atlas: normalized metrics plus the atlas texture
+ * image, ready to be uploaded to the GPU by the rendering module. Produced
+ * by `FontAtlasCache`.
+ */
+export interface FontAtlas {
+  /** The atlas's normalized metrics and glyph data. */
+  readonly data: FontAtlasData;
+
+  /** The loaded atlas texture image, not yet uploaded to the GPU. */
+  readonly image: HTMLImageElement;
+}

--- a/src/text/font-atlas/index.ts
+++ b/src/text/font-atlas/index.ts
@@ -1,0 +1,5 @@
+export * from './font-atlas-cache.js';
+export * from './font-atlas-data.js';
+export * from './font-atlas-file-data.js';
+export * from './font-atlas.js';
+export * from './validate-font-atlas-data.js';

--- a/src/text/font-atlas/validate-font-atlas-data.test.ts
+++ b/src/text/font-atlas/validate-font-atlas-data.test.ts
@@ -83,6 +83,14 @@ describe('validateFontAtlasFileData', () => {
     );
   });
 
+  it('should throw when atlasSize is not an object', () => {
+    const json = { ...buildValidJson(), atlasSize: null };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /atlasSize must be an object/,
+    );
+  });
+
   it('should throw when distanceRange is not finite', () => {
     const json = { ...buildValidJson(), distanceRange: Number.NaN };
 
@@ -106,11 +114,44 @@ describe('validateFontAtlasFileData', () => {
     );
   });
 
+  it('should throw when metrics is not an object', () => {
+    const json = { ...buildValidJson(), metrics: 'nope' };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /metrics must be an object/,
+    );
+  });
+
   it('should throw when glyphs is not an array', () => {
     const json = { ...buildValidJson(), glyphs: {} };
 
     expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
       /glyphs must be an array/,
+    );
+  });
+
+  it('should throw when glyphs has more entries than the sane maximum', () => {
+    const json = {
+      ...buildValidJson(),
+      glyphs: Array.from({ length: 100_001 }, (_, index) => ({
+        codePoint: index,
+        advance: 0.5,
+        planeBounds: null,
+        atlasBounds: null,
+      })),
+    };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /glyphs has 100001 entries, exceeding the maximum of 100000/,
+    );
+  });
+
+  it('should throw when a glyph is not an object', () => {
+    const json = buildValidJson();
+    json.glyphs[0] = null as never;
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /glyphs\[0\] must be an object/,
     );
   });
 
@@ -123,6 +164,15 @@ describe('validateFontAtlasFileData', () => {
     );
   });
 
+  it('should throw when a glyph has a non-finite advance', () => {
+    const json = buildValidJson();
+    json.glyphs[0] = { ...json.glyphs[0], advance: Number.NaN };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /glyphs\[0\]\.advance must be a finite number/,
+    );
+  });
+
   it('should throw when a glyph planeBounds is malformed', () => {
     const json = buildValidJson();
     json.glyphs[0] = {
@@ -132,6 +182,29 @@ describe('validateFontAtlasFileData', () => {
 
     expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
       /glyphs\[0\]\.planeBounds's left, bottom, right, and top must all be finite numbers/,
+    );
+  });
+
+  it('should throw when a glyph planeBounds is not an object or null', () => {
+    const json = buildValidJson();
+    json.glyphs[0] = { ...json.glyphs[0], planeBounds: 'nope' as never };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /glyphs\[0\]\.planeBounds must be a Rect or null/,
+    );
+  });
+
+  it('should throw when kerning has more entries than the sane maximum', () => {
+    const kerning: Record<string, number> = {};
+
+    for (let index = 0; index < 1_000_001; index++) {
+      kerning[getKerningPairKey(index, 0)] = 0;
+    }
+
+    const json = { ...buildValidJson(), kerning };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /kerning has 1000001 entries, exceeding the maximum of 1000000/,
     );
   });
 

--- a/src/text/font-atlas/validate-font-atlas-data.test.ts
+++ b/src/text/font-atlas/validate-font-atlas-data.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CURRENT_FONT_ATLAS_FORMAT_VERSION,
+  getKerningPairKey,
+} from './font-atlas-data.js';
+import type { FontAtlasFileData } from './font-atlas-file-data.js';
+import { validateFontAtlasFileData } from './validate-font-atlas-data.js';
+
+const buildValidJson = (): FontAtlasFileData => ({
+  formatVersion: CURRENT_FONT_ATLAS_FORMAT_VERSION,
+  type: 'msdf',
+  atlasImage: 'my-font.png',
+  atlasSize: { width: 512, height: 512 },
+  distanceRange: 4,
+  metrics: { lineHeight: 1.2, ascender: 0.9, descender: -0.2 },
+  glyphs: [
+    {
+      codePoint: 65,
+      advance: 0.6,
+      planeBounds: { left: 0.05, bottom: 0, right: 0.55, top: 0.7 },
+      atlasBounds: { left: 0.1, bottom: 0.2, right: 0.2, top: 0.3 },
+    },
+    {
+      codePoint: 32,
+      advance: 0.3,
+      planeBounds: null,
+      atlasBounds: null,
+    },
+  ],
+  kerning: {
+    [getKerningPairKey(65, 86)]: -0.05,
+  },
+});
+
+describe('validateFontAtlasFileData', () => {
+  it('should return the data unchanged when it is valid', () => {
+    const json = buildValidJson();
+
+    expect(validateFontAtlasFileData(json, 'fixture.json')).toEqual(json);
+  });
+
+  it('should throw when the root value is not an object', () => {
+    expect(() => validateFontAtlasFileData(null, 'fixture.json')).toThrow(
+      /expected the root value to be a JSON object/,
+    );
+    expect(() => validateFontAtlasFileData('nope', 'fixture.json')).toThrow(
+      /expected the root value to be a JSON object/,
+    );
+  });
+
+  it('should throw a descriptive error when the format version is unsupported', () => {
+    const json = { ...buildValidJson(), formatVersion: 999 };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /unsupported formatVersion "999"/,
+    );
+  });
+
+  it('should throw when the type is not msdf', () => {
+    const json = { ...buildValidJson(), type: 'mtsdf' };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /unsupported type "mtsdf"/,
+    );
+  });
+
+  it('should throw when atlasImage is missing or empty', () => {
+    const json = { ...buildValidJson(), atlasImage: '' };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /atlasImage must be a non-empty string/,
+    );
+  });
+
+  it('should throw when atlasSize is non-positive', () => {
+    const json = {
+      ...buildValidJson(),
+      atlasSize: { width: 0, height: 512 },
+    };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /atlasSize.width and atlasSize.height must be positive finite numbers/,
+    );
+  });
+
+  it('should throw when distanceRange is not finite', () => {
+    const json = { ...buildValidJson(), distanceRange: Number.NaN };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /distanceRange must be a positive finite number/,
+    );
+  });
+
+  it('should throw when metrics has a non-finite field', () => {
+    const json = {
+      ...buildValidJson(),
+      metrics: {
+        lineHeight: 1.2,
+        ascender: Number.POSITIVE_INFINITY,
+        descender: -0.2,
+      },
+    };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /metrics\.lineHeight, metrics\.ascender, and metrics\.descender must all be finite numbers/,
+    );
+  });
+
+  it('should throw when glyphs is not an array', () => {
+    const json = { ...buildValidJson(), glyphs: {} };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /glyphs must be an array/,
+    );
+  });
+
+  it('should throw when a glyph has an invalid codePoint', () => {
+    const json = buildValidJson();
+    json.glyphs[0] = { ...json.glyphs[0], codePoint: -1 };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /glyphs\[0\]\.codePoint must be a non-negative integer/,
+    );
+  });
+
+  it('should throw when a glyph planeBounds is malformed', () => {
+    const json = buildValidJson();
+    json.glyphs[0] = {
+      ...json.glyphs[0],
+      planeBounds: { left: 0, bottom: 0, right: 0, top: Number.NaN },
+    };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /glyphs\[0\]\.planeBounds's left, bottom, right, and top must all be finite numbers/,
+    );
+  });
+
+  it('should throw when kerning is not an object', () => {
+    const json = { ...buildValidJson(), kerning: 'nope' };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /kerning must be an object/,
+    );
+  });
+
+  it('should throw when a kerning key is malformed', () => {
+    const json = { ...buildValidJson(), kerning: { notAPair: 1 } };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /kerning key "notAPair" is not of the form/,
+    );
+  });
+
+  it('should throw when a kerning value is not finite', () => {
+    const json = {
+      ...buildValidJson(),
+      kerning: { [getKerningPairKey(65, 86)]: Number.NaN },
+    };
+
+    expect(() => validateFontAtlasFileData(json, 'fixture.json')).toThrow(
+      /kerning\["65:86"\] must be a finite number/,
+    );
+  });
+
+  it('should include the source path in error messages', () => {
+    expect(() =>
+      validateFontAtlasFileData(null, 'assets/fonts/broken.json'),
+    ).toThrow(/Invalid font atlas JSON at "assets\/fonts\/broken\.json"/);
+  });
+});

--- a/src/text/font-atlas/validate-font-atlas-data.ts
+++ b/src/text/font-atlas/validate-font-atlas-data.ts
@@ -1,0 +1,224 @@
+import { CURRENT_FONT_ATLAS_FORMAT_VERSION } from './font-atlas-data.js';
+import type { FontAtlasFileData } from './font-atlas-file-data.js';
+
+/** Sane upper bound on how many glyphs a single atlas can declare. */
+const MAX_GLYPH_COUNT = 100_000;
+
+/** Sane upper bound on how many kerning pairs a single atlas can declare. */
+const MAX_KERNING_PAIR_COUNT = 1_000_000;
+
+const KERNING_KEY_PATTERN = /^\d+:\d+$/;
+
+/**
+ * Validates that `json` is a well-formed, current-version
+ * `FontAtlasFileData` object, throwing a descriptive error otherwise. This
+ * is the boundary check for atlas files, which may be moddable/user-supplied
+ * content rather than developer-authored assets.
+ * @param json - The parsed JSON to validate.
+ * @param sourcePath - The path the JSON was loaded from, for error messages.
+ * @returns `json`, narrowed to `FontAtlasFileData`.
+ * @throws An error if `json` is not a valid, current-version atlas file.
+ */
+export function validateFontAtlasFileData(
+  json: unknown,
+  sourcePath: string,
+): FontAtlasFileData {
+  const fail = (reason: string): never => {
+    throw new Error(`Invalid font atlas JSON at "${sourcePath}": ${reason}`);
+  };
+
+  if (typeof json !== 'object' || json === null) {
+    fail('expected the root value to be a JSON object.');
+  }
+
+  const data = json as Record<string, unknown>;
+
+  if (data.formatVersion !== CURRENT_FONT_ATLAS_FORMAT_VERSION) {
+    fail(
+      `unsupported formatVersion "${String(data.formatVersion)}", expected ${CURRENT_FONT_ATLAS_FORMAT_VERSION}.`,
+    );
+  }
+
+  if (data.type !== 'msdf') {
+    fail(`unsupported type "${String(data.type)}", expected "msdf".`);
+  }
+
+  if (typeof data.atlasImage !== 'string' || data.atlasImage.length === 0) {
+    fail('atlasImage must be a non-empty string.');
+  }
+
+  validateAtlasSize(data.atlasSize, fail);
+  validateDistanceRange(data.distanceRange, fail);
+  validateMetrics(data.metrics, fail);
+  validateGlyphs(data.glyphs, fail);
+  validateKerning(data.kerning, fail);
+
+  return data as unknown as FontAtlasFileData;
+}
+
+function validateAtlasSize(
+  atlasSize: unknown,
+  fail: (reason: string) => never,
+): void {
+  if (typeof atlasSize !== 'object' || atlasSize === null) {
+    fail('atlasSize must be an object.');
+
+    return;
+  }
+
+  const { width, height } = atlasSize as Record<string, unknown>;
+
+  if (!isPositiveFiniteNumber(width) || !isPositiveFiniteNumber(height)) {
+    fail(
+      'atlasSize.width and atlasSize.height must be positive finite numbers.',
+    );
+  }
+}
+
+function validateDistanceRange(
+  distanceRange: unknown,
+  fail: (reason: string) => never,
+): void {
+  if (!isPositiveFiniteNumber(distanceRange)) {
+    fail('distanceRange must be a positive finite number.');
+  }
+}
+
+function validateMetrics(
+  metrics: unknown,
+  fail: (reason: string) => never,
+): void {
+  if (typeof metrics !== 'object' || metrics === null) {
+    fail('metrics must be an object.');
+
+    return;
+  }
+
+  const { lineHeight, ascender, descender } = metrics as Record<
+    string,
+    unknown
+  >;
+
+  if (
+    !Number.isFinite(lineHeight) ||
+    !Number.isFinite(ascender) ||
+    !Number.isFinite(descender)
+  ) {
+    fail(
+      'metrics.lineHeight, metrics.ascender, and metrics.descender must all be finite numbers.',
+    );
+  }
+}
+
+function validateGlyphs(
+  glyphs: unknown,
+  fail: (reason: string) => never,
+): void {
+  if (!Array.isArray(glyphs)) {
+    fail('glyphs must be an array.');
+
+    return;
+  }
+
+  if (glyphs.length > MAX_GLYPH_COUNT) {
+    fail(
+      `glyphs has ${glyphs.length} entries, exceeding the maximum of ${MAX_GLYPH_COUNT}.`,
+    );
+  }
+
+  for (const [index, glyph] of glyphs.entries()) {
+    validateGlyph(glyph, index, fail);
+  }
+}
+
+function validateGlyph(
+  glyph: unknown,
+  index: number,
+  fail: (reason: string) => never,
+): void {
+  if (typeof glyph !== 'object' || glyph === null) {
+    fail(`glyphs[${index}] must be an object.`);
+
+    return;
+  }
+
+  const { codePoint, advance, planeBounds, atlasBounds } = glyph as Record<
+    string,
+    unknown
+  >;
+
+  if (!Number.isInteger(codePoint) || (codePoint as number) < 0) {
+    fail(`glyphs[${index}].codePoint must be a non-negative integer.`);
+  }
+
+  if (!Number.isFinite(advance)) {
+    fail(`glyphs[${index}].advance must be a finite number.`);
+  }
+
+  validateRectOrNull(planeBounds, `glyphs[${index}].planeBounds`, fail);
+  validateRectOrNull(atlasBounds, `glyphs[${index}].atlasBounds`, fail);
+}
+
+function validateRectOrNull(
+  rect: unknown,
+  fieldPath: string,
+  fail: (reason: string) => never,
+): void {
+  if (rect === null) {
+    return;
+  }
+
+  if (typeof rect !== 'object') {
+    fail(`${fieldPath} must be a Rect or null.`);
+
+    return;
+  }
+
+  const { left, bottom, right, top } = rect as Record<string, unknown>;
+
+  if (
+    !Number.isFinite(left) ||
+    !Number.isFinite(bottom) ||
+    !Number.isFinite(right) ||
+    !Number.isFinite(top)
+  ) {
+    fail(
+      `${fieldPath}'s left, bottom, right, and top must all be finite numbers.`,
+    );
+  }
+}
+
+function validateKerning(
+  kerning: unknown,
+  fail: (reason: string) => never,
+): void {
+  if (typeof kerning !== 'object' || kerning === null) {
+    fail('kerning must be an object.');
+
+    return;
+  }
+
+  const entries = Object.entries(kerning as Record<string, unknown>);
+
+  if (entries.length > MAX_KERNING_PAIR_COUNT) {
+    fail(
+      `kerning has ${entries.length} entries, exceeding the maximum of ${MAX_KERNING_PAIR_COUNT}.`,
+    );
+  }
+
+  for (const [key, value] of entries) {
+    if (!KERNING_KEY_PATTERN.test(key)) {
+      fail(
+        `kerning key "${key}" is not of the form "<leftCodePoint>:<rightCodePoint>".`,
+      );
+    }
+
+    if (!Number.isFinite(value)) {
+      fail(`kerning["${key}"] must be a finite number.`);
+    }
+  }
+}
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -1,0 +1,1 @@
+export * from './font-atlas/index.js';


### PR DESCRIPTION
## Summary

Implements **Phase 1** of `design/msdf-text-rendering.md`: the offline atlas pipeline, on-disk format, and runtime loader. No rendering yet (that's Phase 2) — this is purely the data pipeline, fully testable without a GPU, per the design's own Phase 1 scope and Definition of Done.

- `npm run generate-font-atlas -- --font <path> --out <path> [--charset ascii|<string>|<file>] [--size 42] [--distance-range 4] [--texture-width 512] [--texture-height 512]` (`scripts/generate-font-atlas.mjs`) generates an MSDF atlas PNG plus a normalized, versioned metrics JSON from a `.ttf`/`.otf` font.
- `@forge-game-engine/forge/text` (new module, `/src/text`):
  - `FontAtlasData` / `FontAtlasFileData` — the runtime (`Map`-based) and on-disk (JSON-safe) shapes of a font atlas's metrics (`GlyphMetrics`, kerning, line metrics), versioned via `formatVersion` (DL-03).
  - `validateFontAtlasFileData` — throws a descriptive error on malformed/incompatible-version atlas JSON rather than failing deep inside a future shaping system (§5.13/§5.12).
  - `FontAtlasCache` (implements the existing `AssetCache<T>` contract) — loads an atlas's JSON + image (via the existing `ImageCache`) into a `FontAtlas`.
- Verified end-to-end against a real system font (DejaVu Sans): generated an atlas, then loaded and validated it through the actual `FontAtlasCache`/`validateFontAtlasFileData`/`toFontAtlasData` runtime path.

### Deviation from the design doc: generator tool

DL-02 proposed wrapping `msdf-atlas-gen` (native binary via its npm wrapper). That npm package transitively pulls in `google-font-metadata` → `puppeteer`, whose postinstall step downloads a full Chrome browser — a heavy, unrelated, and fragile dependency for a devDependency-only build tool (it failed outright in this sandbox and would be a flaky `npm ci` step in CI). Instead this wraps [`msdf-bmfont-xml`](https://github.com/soimy/msdf-bmfont-xml), which bundles prebuilt `msdfgen` binaries directly (same underlying reference implementation DL-02 calls for), has no network-dependent postinstall, and is called as a plain library function rather than shelled out to. `npm audit --omit=dev` shows 0 vulnerabilities from this addition.

## Related issue(s)

N/A

## Verification checklist

- [x] `npm run check-types` passes with 0 errors
- [x] `npm test` passes (1062 tests, including 26 new)
- [x] `npm run lint` passes with 0 errors
- [x] `npm run cspell` passes with 0 errors
- [x] `npm run check-exports` passes
- [x] New public API is exported from `src/text/index.ts`, `/src/index.ts`, and `package.json` `exports` (`./text`)
- [ ] Documentation under `/documentation-site/docs/docs` — intentionally not added; the design doc defers the conceptual guide to Phase 5, once there's a renderable feature to document
- [ ] No demo under `/documentation-site/src/pages/demos` references this module yet (n/a for this phase)

## Changelog

- [x] A bullet has been added under `## [Unreleased]` → `#### Added` in `CHANGELOG.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SAHCUFuDsbsYiYGpt25AhC)_