### PR TITLE
feat(create-game): add error handling for missing container element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **math:** `Vector2`/`Vector3` are now plain `{ x, y }`/`{ x, y, z }` objects instead of classes, constructed with an object literal (`{ x: 1, y: 2 }`) and operated on via `Vec2`/`Vec3` static methods (`Vec2.add`, `Vec2.rotate`, `Vec2.normalize`, etc.) that mutate their first (`target`) argument in place and return it, rather than allocating a new vector, for performance in hot loops like physics integration; see the "Vectors and Rectangles" doc for the full API and migration guidance. **Breaking change.**
 - **math:** `Vec2.normalize`/`Vec3.normalize` now throw when given a zero-length vector instead of silently returning it unchanged, since a normalized direction is undefined for a zero vector. **Breaking change.**
+- **utils:** `createGame` utility now throws a more useful error message when no matching DOM element is found that has the id matching `containerId`
 
 #### Removed
 

--- a/src/utilities/create-game.test.ts
+++ b/src/utilities/create-game.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGame, EcsWorld, Game, Time } from '../index.js';
+import { createCanvas, createRenderContext } from '../rendering/index.js';
+
+vi.mock('../rendering/index.js', () => ({
+  createCanvas: vi.fn(),
+  createRenderContext: vi.fn(),
+}));
+
+describe('createGame', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    const container = document.createElement('div');
+    container.id = 'game-container';
+    document.body.appendChild(container);
+  });
+
+  it('returns an instance of Game', () => {
+    const { game } = createGame('game-container');
+    expect(game).toBeInstanceOf(Game);
+  });
+
+  it('returns an instance of EcsWorld', () => {
+    const { world } = createGame('game-container');
+    expect(world).toBeInstanceOf(EcsWorld);
+  });
+
+  it('returns an instance of Time', () => {
+    const { time } = createGame('game-container');
+    expect(time).toBeInstanceOf(Time);
+  });
+
+  it('creates a canvas', () => {
+    createGame('game-container');
+
+    expect(createCanvas).toHaveBeenCalled();
+  });
+
+  it('creates a render context', () => {
+    createGame('game-container');
+
+    expect(createRenderContext).toHaveBeenCalled();
+  });
+
+  it('throws an error if the container element is not found', () => {
+    expect(() => createGame('non-existent-container')).toThrow(
+      'No DOM element with ID "non-existent-container" found.',
+    );
+  });
+});

--- a/src/utilities/create-game.ts
+++ b/src/utilities/create-game.ts
@@ -20,7 +20,12 @@ export function createGame(containerId: string): {
 } {
   const time = new Time();
   const world = new EcsWorld();
-  const container = document.getElementById(containerId)!;
+  const container = document.getElementById(containerId);
+
+  if (!container) {
+    throw new Error(`No DOM element with ID "${containerId}" found.`);
+  }
+
   const game = new Game(time, world, container);
 
   const canvas = createCanvas(container);


### PR DESCRIPTION
## Summary

<!-- Describe what this change does and why. -->

## Related issue(s)

<!-- e.g. Closes #123 -->

## Verification checklist

<!-- See CONTRIBUTING.md and CLAUDE.md for details on each step. -->

- [x] `npm run check-types` passes with 0 errors
- [x] `npm test` passes
- [x] `npm run lint` passes with 0 errors
- [x] `npm run cspell` passes with 0 errors
- [x] `npm run check-exports` passes
- [x] Any new/changed public API is exported from the module's `index.ts`
      (and `/src/index.ts` / `package.json` `exports` if it's a new module)
- [x] Documentation under `/documentation-site/docs/docs` is updated if this
      change affects documented behavior
- [x] If this change touches a module with a demo under
      `/documentation-site/src/pages/demos`, the demo has been updated and
      verified (see AGENTS.md's "Documentation Site Demos" section)

## Changelog

- [x] A bullet has been added under `## [Unreleased]` in `CHANGELOG.md`
      (required unless this PR's Conventional Commits type is `chore`,
      `style`, `refactor`, `test`, `ci`, `docs`, or `build` — see
      AGENTS.md's "Changelog" section)
