### PR TITLE
feat(create-image-sprite): add optional layer parameter to sprite opt…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **math:** `Vector2`/`Vector3` are now plain `{ x, y }`/`{ x, y, z }` objects instead of classes, constructed with an object literal (`{ x: 1, y: 2 }`) and operated on via `Vec2`/`Vec3` static methods (`Vec2.add`, `Vec2.rotate`, `Vec2.normalize`, etc.) that mutate their first (`target`) argument in place and return it, rather than allocating a new vector, for performance in hot loops like physics integration; see the "Vectors and Rectangles" doc for the full API and migration guidance. **Breaking change.**
 - **math:** `Vec2.normalize`/`Vec3.normalize` now throw when given a zero-length vector instead of silently returning it unchanged, since a normalized direction is undefined for a zero vector. **Breaking change.**
 - **utils:** `createGame` utility now throws a more useful error message when no matching DOM element is found that has the id matching `containerId`
-- **utils:** `createImageSprite` now makes layer an optional value in the options argument rather than a required arguument to the function. Defaults to `1`.
+- **utils:** `createImageSprite` now makes layer an optional value in the options argument rather than a required argument to the function. Defaults to `1`.
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **math:** `Vector2`/`Vector3` are now plain `{ x, y }`/`{ x, y, z }` objects instead of classes, constructed with an object literal (`{ x: 1, y: 2 }`) and operated on via `Vec2`/`Vec3` static methods (`Vec2.add`, `Vec2.rotate`, `Vec2.normalize`, etc.) that mutate their first (`target`) argument in place and return it, rather than allocating a new vector, for performance in hot loops like physics integration; see the "Vectors and Rectangles" doc for the full API and migration guidance. **Breaking change.**
 - **math:** `Vec2.normalize`/`Vec3.normalize` now throw when given a zero-length vector instead of silently returning it unchanged, since a normalized direction is undefined for a zero vector. **Breaking change.**
 - **utils:** `createGame` utility now throws a more useful error message when no matching DOM element is found that has the id matching `containerId`
+- **utils:** `createImageSprite` now makes layer an optional value in the options argument rather than a required arguument to the function. Defaults to `1`.
 
 #### Removed
 

--- a/demo/src/game.ts
+++ b/demo/src/game.ts
@@ -1,4 +1,23 @@
-import { addPositionComponent, addRotationComponent, addSpriteComponent, calculateVisibleWorldSize, Color, createCamera, createGame, createImageSprite, createRenderEcsSystem, degreesToRadians, EcsSystem, EcsWorld, PositionEcsComponent, positionId, Random, SpriteEcsComponent, Time, Vec2 } from '../../src';
+import {
+  addPositionComponent,
+  addRotationComponent,
+  addSpriteComponent,
+  calculateVisibleWorldSize,
+  Color,
+  createCamera,
+  createGame,
+  createImageSprite,
+  createRenderEcsSystem,
+  degreesToRadians,
+  EcsSystem,
+  EcsWorld,
+  PositionEcsComponent,
+  positionId,
+  Random,
+  SpriteEcsComponent,
+  Time,
+  Vec2,
+} from '../../src';
 import {
   addAabbComponent,
   addColliderComponent,
@@ -86,7 +105,10 @@ function createFountainSpawnEcsSystem(
       random.randomFloat(1 - fountainSpeedJitter, 1 + fountainSpeedJitter);
     const horizontalDirection = side === 'left' ? 1 : -1;
 
-    const velocity = { x: Math.cos(angle) * speed * horizontalDirection, y: Math.sin(angle) * speed };
+    const velocity = {
+      x: Math.cos(angle) * speed * horizontalDirection,
+      y: Math.sin(angle) * speed,
+    };
     const angularVelocity = random.randomFloat(
       -template.angularVelocitySpread,
       template.angularVelocitySpread,
@@ -228,21 +250,18 @@ const [ballImage, squareImage, triangleImage] = await Promise.all([
   imageCache.getOrLoad('Triangle.png'),
 ]);
 
-const ballSprite = createImageSprite(ballImage, renderContext, renderLayer, {
+const ballSprite = createImageSprite(ballImage, renderContext, {
   frameDimensions: { x: shapeSize, y: shapeSize },
+  layer: renderLayer,
 });
-const squareSprite = createImageSprite(
-  squareImage,
-  renderContext,
-  renderLayer,
-  { frameDimensions: { x: shapeSize, y: shapeSize } },
-);
-const triangleSprite = createImageSprite(
-  triangleImage,
-  renderContext,
-  renderLayer,
-  { frameDimensions: { x: shapeSize, y: shapeSize } },
-);
+const squareSprite = createImageSprite(squareImage, renderContext, {
+  frameDimensions: { x: shapeSize, y: shapeSize },
+  layer: renderLayer,
+});
+const triangleSprite = createImageSprite(triangleImage, renderContext, {
+  frameDimensions: { x: shapeSize, y: shapeSize },
+  layer: renderLayer,
+});
 
 triangleSprite.pivot = Vec2.clone(trianglePivot);
 

--- a/src/rendering/utilities/create-image-sprite.test.ts
+++ b/src/rendering/utilities/create-image-sprite.test.ts
@@ -122,7 +122,7 @@ describe('createImageSprite', () => {
   });
 
   it('binds zero emissive intensity when no emissive map is given', () => {
-    const sprite = createImageSprite(image, renderContext, 0);
+    const sprite = createImageSprite(image, renderContext);
 
     sprite.renderable.material.bind(mockGl);
 
@@ -135,8 +135,8 @@ describe('createImageSprite', () => {
   });
 
   it('binds the same shared black placeholder texture across sprites with no emissive map', () => {
-    const spriteA = createImageSprite(image, renderContext, 0);
-    const spriteB = createImageSprite(image, renderContext, 0);
+    const spriteA = createImageSprite(image, renderContext);
+    const spriteB = createImageSprite(image, renderContext);
 
     spriteA.renderable.material.bind(mockGl);
     const [, spriteAEmissiveTexture] = (mockGl.bindTexture as Mock).mock
@@ -151,7 +151,7 @@ describe('createImageSprite', () => {
   });
 
   it('sets the configured emissive intensity when an emissive map is given', () => {
-    const sprite = createImageSprite(image, renderContext, 0, {
+    const sprite = createImageSprite(image, renderContext, {
       emissiveMap: {
         image: emissiveImage,
         intensity: 3,
@@ -169,7 +169,7 @@ describe('createImageSprite', () => {
   });
 
   it('defaults emissive intensity to 1 when an emissive map is given without an explicit intensity', () => {
-    const sprite = createImageSprite(image, renderContext, 0, {
+    const sprite = createImageSprite(image, renderContext, {
       emissiveMap: {
         image: emissiveImage,
       },
@@ -185,11 +185,11 @@ describe('createImageSprite', () => {
   });
 
   it('does not throw when creating a sprite without an emissive map', () => {
-    expect(() => createImageSprite(image, renderContext, 0)).not.toThrow();
+    expect(() => createImageSprite(image, renderContext)).not.toThrow();
   });
 
   it('defaults the emissive color to white when an emissive map is given without an explicit color', () => {
-    const sprite = createImageSprite(image, renderContext, 0, {
+    const sprite = createImageSprite(image, renderContext, {
       emissiveMap: {
         image: emissiveImage,
       },
@@ -206,7 +206,7 @@ describe('createImageSprite', () => {
   });
 
   it('sets the configured emissive color when given', () => {
-    const sprite = createImageSprite(image, renderContext, 0, {
+    const sprite = createImageSprite(image, renderContext, {
       emissiveMap: {
         image: emissiveImage,
         color: new Color(1, 0.5, 0.1),
@@ -225,7 +225,7 @@ describe('createImageSprite', () => {
   });
 
   it('sets the emissive color to white when no emissive map is given', () => {
-    const sprite = createImageSprite(image, renderContext, 0);
+    const sprite = createImageSprite(image, renderContext);
 
     sprite.renderable.material.bind(mockGl);
 

--- a/src/rendering/utilities/create-image-sprite.ts
+++ b/src/rendering/utilities/create-image-sprite.ts
@@ -71,6 +71,11 @@ export interface CreateImageSpriteOptions {
    * single-quad sprite.
    */
   slices?: NineSliceOptions;
+
+  /**
+   * The render layer for the sprite. Defaults to `1`.
+   */
+  layer?: number;
 }
 
 // `color` isn't included here: `Color.white` can't be read at module-init
@@ -81,7 +86,7 @@ export interface CreateImageSpriteOptions {
 // actually called, well after every module has finished loading.
 const defaultEmissiveMapOptions = { intensity: 1 };
 
-const defaultCreateImageSpriteOptions = { pixelated: false };
+const defaultCreateImageSpriteOptions = { pixelated: false, layer: 1 };
 
 /**
  * Creates a sprite using the provided image and render layer.
@@ -94,11 +99,13 @@ const defaultCreateImageSpriteOptions = { pixelated: false };
 export function createImageSprite(
   image: HTMLImageElement,
   renderContext: RenderContext,
-  layer: number,
   options: CreateImageSpriteOptions = {},
 ): SpriteEcsComponent {
   const { shaderCache, gl } = renderContext;
-  const { pixelated } = { ...defaultCreateImageSpriteOptions, ...options };
+  const { pixelated, layer } = {
+    ...defaultCreateImageSpriteOptions,
+    ...options,
+  };
 
   const spriteVertexShader = shaderCache.getShader('sprite.vert');
   const spriteFragmentShader = shaderCache.getShader('sprite.frag');


### PR DESCRIPTION
…ions

## Summary

<!-- Describe what this change does and why. -->

## Related issue(s)

<!-- e.g. Closes #123 -->

## Verification checklist

<!-- See CONTRIBUTING.md and CLAUDE.md for details on each step. -->

- [ ] `npm run check-types` passes with 0 errors
- [ ] `npm test` passes
- [ ] `npm run lint` passes with 0 errors
- [ ] `npm run cspell` passes with 0 errors
- [ ] `npm run check-exports` passes
- [ ] Any new/changed public API is exported from the module's `index.ts`
      (and `/src/index.ts` / `package.json` `exports` if it's a new module)
- [ ] Documentation under `/documentation-site/docs/docs` is updated if this
      change affects documented behavior
- [ ] If this change touches a module with a demo under
      `/documentation-site/src/pages/demos`, the demo has been updated and
      verified (see AGENTS.md's "Documentation Site Demos" section)

## Changelog

- [ ] A bullet has been added under `## [Unreleased]` in `CHANGELOG.md`
      (required unless this PR's Conventional Commits type is `chore`,
      `style`, `refactor`, `test`, `ci`, `docs`, or `build` — see
      AGENTS.md's "Changelog" section)
